### PR TITLE
Add failing test with static string creator using paranamer.

### DIFF
--- a/paranamer/src/test/java/com/fasterxml/jackson/module/paranamer/TestCreatorWithNamingStrategy.java
+++ b/paranamer/src/test/java/com/fasterxml/jackson/module/paranamer/TestCreatorWithNamingStrategy.java
@@ -21,6 +21,29 @@ public class TestCreatorWithNamingStrategy
         }
     }
 
+    static class StaticStringCreatorBean
+    {
+        protected String myName;
+        protected int myAge;
+
+        public StaticStringCreatorBean(int myAge, String myName)
+        {
+            this.myName = myName;
+            this.myAge = myAge;
+        }
+
+        @JsonCreator
+        public static StaticStringCreatorBean parse(String delimited)
+        {
+            String[] args = delimited.split("\\|");
+            if (args.length != 2) {
+                throw new IllegalArgumentException("Invalid string: " + delimited + ". Expected 'age|name'.");
+            }
+            int age = Integer.parseInt(args[0]);
+            return new StaticStringCreatorBean(age, args[1]);
+        }
+    }
+
     private final ObjectMapper MAPPER = new ObjectMapper()
             .registerModule(new ParanamerModule())
             .setPropertyNamingStrategy(PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE);
@@ -32,4 +55,10 @@ public class TestCreatorWithNamingStrategy
         assertEquals("NotMyRealName", bean.myName);
     }
 
+    public void testStaticStringCreator() throws Exception
+    {
+        StaticStringCreatorBean bean = MAPPER.readValue("\"42|NotMyRealName\"", StaticStringCreatorBean.class);
+        assertEquals(42, bean.myAge);
+        assertEquals("NotMyRealName", bean.myName);
+    }
 }


### PR DESCRIPTION
This is a simplified test that is causing the Scala module to be incompatible with Dropwizard's Duration and et all (FasterXML/jackson-module-scala#229). 

This test passes if you remove the `registerModule(new ParnamerModule())`. The only piece of the module required to trigger this issue is the `ParanamerAnnotationIntrospector`.

It fails inside of `BeanDeserializerFactory` because it cannot find `Delimited` as a constructor argument (it's not, it's an argument of the creator).

```
com.fasterxml.jackson.databind.JsonMappingException: Could not find creator property with name 'Delimited' (in class com.fasterxml.jackson.module.paranamer.TestCreatorWithNamingStrategy$StaticStringCreatorBean)
 at [Source: "42|NotMyRealName"; line: 1, column: 1]

	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:255)
	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:992)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.addBeanProps(BeanDeserializerFactory.java:541)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.buildBeanDeserializer(BeanDeserializerFactory.java:228)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:143)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer2(DeserializerCache.java:406)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:352)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:264)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
	at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:142)
	at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:477)
	at com.fasterxml.jackson.databind.ObjectMapper._findRootDeserializer(ObjectMapper.java:3908)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3803)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2797)
	at com.fasterxml.jackson.module.paranamer.TestCreatorWithNamingStrategy.testStaticStringCreator(TestCreatorWithNamingStrategy.java:60)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:234)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:74)
```