### PR TITLE
Fixed typo of generated serializer name

### DIFF
--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/ser/PropertyAccessorCollector.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/ser/PropertyAccessorCollector.java
@@ -93,7 +93,7 @@ public class PropertyAccessorCollector
         if (classLoader == null) {
             classLoader = new MyClassLoader(beanClass.getClassLoader(), true);
         }
-        final ClassName baseName = ClassName.constructFor(beanClass, "$Access4JacksonDeserializer");
+        final ClassName baseName = ClassName.constructFor(beanClass, "$Access4JacksonSerializer");
         Class<?> accessorClass = generateAccessorClass(classLoader, baseName);
         try {
             return (BeanPropertyAccessor) accessorClass.newInstance();

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestSimpleDeserialize.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestSimpleDeserialize.java
@@ -348,7 +348,6 @@ public class TestSimpleDeserialize extends AfterburnerTestBase
             if (clz == null) {
                 break;
             }
-            System.out.println(clz.getCanonicalName());
             if (clz.getCanonicalName() != null
                     && clz.getCanonicalName().startsWith(expectedClassName)) {
                 found = true;

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestSimpleSerialize.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestSimpleSerialize.java
@@ -1,5 +1,8 @@
 package com.fasterxml.jackson.module.afterburner.ser;
 
+import java.lang.reflect.Field;
+import java.util.Vector;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -111,7 +114,11 @@ public class TestSimpleSerialize extends AfterburnerTestBase
         public boolean a = true;
         public boolean getB() { return false; }
     }
-    
+
+    static class CheckGeneratedSerializerName {
+        public String stringField;
+    }
+
     /*
     /**********************************************************************
     /* Test methods, method access
@@ -214,5 +221,34 @@ public class TestSimpleSerialize extends AfterburnerTestBase
         String jsonPlain = plainMapper.writeValueAsString(input);
         String jsonAb = abMapper.writeValueAsString(input);
         assertEquals(jsonPlain, jsonAb);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGeneratedSerializerName() throws Exception {
+        CheckGeneratedSerializerName bean = new CheckGeneratedSerializerName();
+        bean.stringField = "bar";
+        ObjectMapper mapper = mapperWithModule();
+        mapper.writeValueAsString(bean);
+        ClassLoader cl = getClass().getClassLoader();
+        Field declaredField = ClassLoader.class.getDeclaredField("classes");
+        declaredField.setAccessible(true);
+        Class<?>[] os = new Class[2048];
+        ((Vector<Class<?>>) declaredField.get(cl)).copyInto(os);
+        String expectedClassName = TestSimpleSerialize.class.getCanonicalName()
+                + "$CheckGeneratedSerializerName$Access4JacksonSerializer";
+        boolean found = false;
+        for (int i = 0; i < os.length; i++) {
+            Class<?> clz = os[i];
+            if (clz == null) {
+                break;
+            }
+            System.out.println(clz.getCanonicalName());
+            if (clz.getCanonicalName() != null
+                    && clz.getCanonicalName().startsWith(expectedClassName)) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue("Expected class not found:" + expectedClassName, found);
     }
 }

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestSimpleSerialize.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestSimpleSerialize.java
@@ -242,7 +242,6 @@ public class TestSimpleSerialize extends AfterburnerTestBase
             if (clz == null) {
                 break;
             }
-            System.out.println(clz.getCanonicalName());
             if (clz.getCanonicalName() != null
                     && clz.getCanonicalName().startsWith(expectedClassName)) {
                 found = true;


### PR DESCRIPTION
Hi,

Thank you for the great software! I learned a lot about asm!
But one thing I noticed that generated serializer/deserializer uses same name. So if the binary check sum is matched, it might be a problem so I made a small changes in order to use different name.

Thank you