### PR TITLE
Allowing Guice 4.x series

### DIFF
--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/FasterXML/jackson-modules-base</url>
 
     <properties>
-        <version.guice>3.0</version.guice>
+        <version.guice>[3.0,5.0)</version.guice>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/guice</packageVersion.dir>


### PR DESCRIPTION
There were [many changes in Guice 4.0](http://google.github.io/guice/api-docs/4.0/api-diffs/changes.html). But all interfaces actually used in jackson-module-guice are still compatible between Guice 3.0 and Guice 4.1.
[Changes of Guice 4.1](http://google.github.io/guice/api-docs/4.1/api-diffs/changes.html) were conservative. I think that it is reasonable to expand range from `4.0]` to `5.0)`.
It might be better that README.md recommends users to specify a fixed version of Guice as well as dependency to jackson-module-guice in application's pom.xml file.
