### PR TITLE
Replace ASM code-gen with ByteBuddy in afterburner

### DIFF
--- a/afterburner/pom.xml
+++ b/afterburner/pom.xml
@@ -15,6 +15,7 @@ field access and method calls
   <url>https://github.com/FasterXML/jackson-modules-base</url>
 
   <properties>
+    <version.butebuddy>1.7.8</version.butebuddy>
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/module/afterburner</packageVersion.dir>
     <packageVersion.package>${project.groupId}.afterburner</packageVersion.package>
@@ -27,7 +28,7 @@ field access and method calls
        Similarly, org.objectweb.asm is shaded... why require?
        (will try to hide via resolution directive)
       -->
-    <osgi.import>org.objectweb.asm;resolution:=optional,
+    <osgi.import>net.bytebuddy;resolution:=optional,
 *
      </osgi.import>
 <!--
@@ -48,9 +49,9 @@ field access and method calls
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>${version.asm}</version>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${version.butebuddy}</version>
     </dependency>
     <dependency> <!--  tests use Jackson annoations -->
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -74,7 +75,7 @@ field access and method calls
       </plugin>
 
       <plugin>
-        <!--  We will shade ASM, to simplify deployment, avoid version conflicts -->
+        <!--  We will shade ByteBuddy, to simplify deployment, avoid version conflicts -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
@@ -86,13 +87,13 @@ field access and method calls
             <configuration>
               <artifactSet>
                 <includes>
-                  <include>org.ow2.asm:asm</include>
+                  <include>net.bytebuddy:byte-buddy</include>
                 </includes>
               </artifactSet>
               <relocations>
                 <relocation>
-                  <pattern>org.objectweb.asm</pattern>
-                  <shadedPattern>com.fasterxml.jackson.module.afterburner.asm</shadedPattern>
+                  <pattern>net.bytebuddy</pattern>
+                  <shadedPattern>com.fasterxml.jackson.module.afterburner.bytebuddy</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/DynamicPropertyAccessorBase.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/DynamicPropertyAccessorBase.java
@@ -1,19 +1,10 @@
 package com.fasterxml.jackson.module.afterburner.util;
 
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.List;
-
-import org.objectweb.asm.MethodVisitor;
-
-import static org.objectweb.asm.Opcodes.*;
 
 public class DynamicPropertyAccessorBase
 {
-    protected final static int[] ALL_INT_CONSTS = new int[] {
-        ICONST_0, ICONST_1, ICONST_2, ICONST_3, ICONST_4
-    };
 
     protected int _accessorCount = 0;
 
@@ -23,27 +14,6 @@ public class DynamicPropertyAccessorBase
     public final boolean isEmpty() {
         return (_accessorCount == 0);
     }
-
-    /*
-    /**********************************************************
-    /* Helper methods, generating common pieces
-    /**********************************************************
-     */
-    
-    protected static void generateException(MethodVisitor mv, String beanClass, int propertyCount)
-    {
-        mv.visitTypeInsn(NEW, "java/lang/IllegalArgumentException");
-        mv.visitInsn(DUP);
-        mv.visitTypeInsn(NEW, "java/lang/StringBuilder");
-        mv.visitInsn(DUP);
-        mv.visitLdcInsn("Invalid field index (valid; 0 <= n < "+propertyCount+"): ");
-        mv.visitMethodInsn(INVOKESPECIAL, "java/lang/StringBuilder", "<init>", "(Ljava/lang/String;)V", false);
-        mv.visitVarInsn(ILOAD, 2);
-        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(I)Ljava/lang/StringBuilder;", false);
-        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false);
-        mv.visitMethodInsn(INVOKESPECIAL, "java/lang/IllegalArgumentException", "<init>", "(Ljava/lang/String;)V", false);
-        mv.visitInsn(ATHROW);
-    }
     
     /*
     /**********************************************************
@@ -51,27 +21,10 @@ public class DynamicPropertyAccessorBase
     /**********************************************************
      */
 
-    /**
-     * @since 2.9.2
-     */
-    protected static boolean isInterfaceMethod(Method method) {
-        // 15-Sep-2017, tatu: As per [modules-base#30], Java 8 default methods need to be called as
-        //   non-interface methods (since they generate real concrete methods). So further checks
-        //   needed, not just that they are declared in an interface
-
-        // Forward compatible with Java 8 equivalent: method.getDeclaringClass().isInterface() && !method.isDefault()
-        // NOTE: `ABSTRACT` is really the key here: only "pure" interface methods abstract; default ones not.
-        return method.getDeclaringClass().isInterface() &&
-                ((method.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) != Modifier.PUBLIC);
-    }
-
-    protected static String internalClassName(String className) {
-        return className.replace(".", "/");
-    }
-    
     protected <T> T _add(List<T> list, T value) {
         list.add(value);
         ++_accessorCount;
         return value;
     }
+
 }

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/AbstractCreateLocalVarStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/AbstractCreateLocalVarStackManipulation.java
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.assign.TypeCasting;
+import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adds bytecode for operation like:
+ * <pre>
+ * {@code
+ * Bean varX = (Bean)var1;
+ * }
+ * <pre/>
+ *
+ * The BytecodeAppender that adds this StackManipulation needs to manually increment the number of
+ * local variables by one
+ */
+public abstract class AbstractCreateLocalVarStackManipulation extends AbstractPropertyStackManipulation {
+    private final TypeDescription beanClassDescription;
+
+    public AbstractCreateLocalVarStackManipulation(
+            TypeDescription beanClassDescription,
+            AbstractPropertyStackManipulation.LocalVarIndexCalculator localVarIndexCalculator) {
+        super(localVarIndexCalculator);
+        this.beanClassDescription = beanClassDescription;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor,
+                      Implementation.Context implementationContext) {
+
+        final List<StackManipulation> operations = new ArrayList<StackManipulation>();
+
+        operations.add(MethodVariableAccess.REFERENCE.loadFrom(beanArgIndex())); //load the bean
+        operations.add(TypeCasting.to(beanClassDescription));
+
+        operations.add(MethodVariableAccess.REFERENCE.storeAt(localVarIndexCalculator.calculate()));
+
+        final StackManipulation.Compound compound = new StackManipulation.Compound(operations);
+        return compound.apply(methodVisitor, implementationContext);
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/AbstractDelegatingAppender.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/AbstractDelegatingAppender.java
@@ -1,0 +1,59 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides the basic algorithm for adding the starting and ending parts of method implementations
+ * as well as handling the delegation to the proper appender
+ * Should not be called when no properties are needed
+ */
+public abstract class AbstractDelegatingAppender<T> implements ByteCodeAppender {
+
+    private final int propsSize;
+
+    public AbstractDelegatingAppender(List<T> props) {
+        this.propsSize = props.size();
+    }
+
+    /*
+     * The following methods should use the fields of the class in order to instantiate the proper type
+     */
+    abstract protected StackManipulation createLocalVar();
+    abstract protected StackManipulation usingSwitch();
+    abstract protected StackManipulation usingIf();
+    abstract protected StackManipulation single();
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor,
+                      Implementation.Context implementationContext,
+                      MethodDescription instrumentedMethod) {
+
+        final List<StackManipulation> stackManipulations = new ArrayList<StackManipulation>();
+        //contains the initial bytecode needed for all cases
+        stackManipulations.add(createLocalVar());
+
+        // Ok; minor optimization, 3 or fewer fields, just do IFs; over that, use switch
+        switch (propsSize) {
+            case 1:
+                stackManipulations.add(single());
+                break;
+            case 2:
+            case 3:
+                stackManipulations.add(usingIf());
+                break;
+            default:
+                stackManipulations.add(usingSwitch());
+        }
+
+        final StackManipulation.Compound compound = new StackManipulation.Compound(stackManipulations);
+        final StackManipulation.Size operandStackSize = compound.apply(methodVisitor, implementationContext);
+        return new Size(operandStackSize.getMaximalSize(), instrumentedMethod.getStackSize() + 1);
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/AbstractPropertyStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/AbstractPropertyStackManipulation.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
+
+/**
+ * Contains base methods that common between the code used in
+ * {@link com.fasterxml.jackson.module.afterburner.deser.PropertyMutatorCollector} and
+ * {@link com.fasterxml.jackson.module.afterburner.ser.PropertyAccessorCollector}
+ */
+public abstract class AbstractPropertyStackManipulation implements StackManipulation {
+
+    protected final LocalVarIndexCalculator localVarIndexCalculator;
+
+    public AbstractPropertyStackManipulation(LocalVarIndexCalculator localVarIndexCalculator) {
+        this.localVarIndexCalculator = localVarIndexCalculator;
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+    public final int beanArgIndex() {
+        return 1;
+    }
+
+    public final int fieldIndexArgIndex() {
+        return 2;
+    }
+
+    public final StackManipulation loadFieldIndexArg() {
+        return MethodVariableAccess.INTEGER.loadFrom(fieldIndexArgIndex());
+    }
+
+    protected final int localVarIndex() {
+        return localVarIndexCalculator.calculate();
+    }
+
+    public interface LocalVarIndexCalculator {
+
+        int calculate();
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/ConstructorCallStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/ConstructorCallStackManipulation.java
@@ -1,0 +1,240 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.Duplication;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.TypeCreation;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static net.bytebuddy.description.method.MethodDescription.ForLoadedConstructor;
+import static net.bytebuddy.description.method.MethodDescription.InDefinedShape;
+import static net.bytebuddy.implementation.bytecode.member.MethodInvocation.invoke;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+/**
+ * Base class for providing a constructor call Implementation
+ */
+public abstract class ConstructorCallStackManipulation implements StackManipulation {
+
+    private final List<StackManipulation> constructorArgumentLoadingOperations;
+
+    public ConstructorCallStackManipulation() {
+        this(new ArrayList<StackManipulation>());
+    }
+
+    public ConstructorCallStackManipulation(StackManipulation... constructorArgumentLoadingOperations) {
+        this(Arrays.asList(constructorArgumentLoadingOperations));
+    }
+
+    public ConstructorCallStackManipulation(List<StackManipulation> constructorArgumentLoadingOperations) {
+        this.constructorArgumentLoadingOperations =
+                null == constructorArgumentLoadingOperations ?
+                        new ArrayList<StackManipulation>() :
+                        constructorArgumentLoadingOperations;
+    }
+
+    public abstract TypeDescription determineTypeDescription(Implementation.Context implementationContext);
+    public abstract InDefinedShape determineConstructor(TypeDescription typeDescription);
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public StackManipulation.Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        final TypeDescription typeDescription = determineTypeDescription(implementationContext);
+
+        final List<StackManipulation> stackManipulations = new ArrayList<>();
+        stackManipulations.add(TypeCreation.of(typeDescription)); //new
+        stackManipulations.add(Duplication.of(typeDescription)); //dup
+        stackManipulations.addAll(constructorArgumentLoadingOperations); //load any needed variables
+        stackManipulations.add(invoke(determineConstructor(typeDescription))); //invokespecial
+
+        final StackManipulation.Compound delegate = new StackManipulation.Compound(stackManipulations);
+        return delegate.apply(methodVisitor, implementationContext);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConstructorCallStackManipulation that = (ConstructorCallStackManipulation) o;
+
+        return constructorArgumentLoadingOperations != null ? constructorArgumentLoadingOperations.equals(that.constructorArgumentLoadingOperations) : that.constructorArgumentLoadingOperations == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return constructorArgumentLoadingOperations != null ? constructorArgumentLoadingOperations.hashCode() : 0;
+    }
+
+    /**
+     * To be used when a reference to java.lang.reflect.Constructor needs to be invoked
+     */
+    public static class KnownConstructorOfExistingType extends ConstructorCallStackManipulation {
+
+        private final Constructor<?> ctor;
+        private final TypeDescription typeDescription;
+
+        public KnownConstructorOfExistingType(Constructor<?> ctor) {
+            this(ctor, new ArrayList<StackManipulation>());
+        }
+
+        public KnownConstructorOfExistingType(Constructor<?> ctor,
+                                              StackManipulation... constructorArgumentLoadingOperations) {
+            this(ctor, Arrays.asList(constructorArgumentLoadingOperations));
+        }
+
+        public KnownConstructorOfExistingType(Constructor<?> ctor,
+                                              List<StackManipulation> constructorArgumentLoadingOperations) {
+            super(constructorArgumentLoadingOperations);
+            this.ctor = ctor;
+            typeDescription = new TypeDescription.ForLoadedType(ctor.getDeclaringClass());
+        }
+
+        @Override
+        public TypeDescription determineTypeDescription(Implementation.Context implementationContext) {
+            return typeDescription;
+        }
+
+        @Override
+        public InDefinedShape determineConstructor(TypeDescription typeDescription) {
+            return new ForLoadedConstructor(ctor);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+
+            KnownConstructorOfExistingType that = (KnownConstructorOfExistingType) o;
+
+            return ctor.equals(that.ctor);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + ctor.hashCode();
+            return result;
+        }
+    }
+
+    public static class KnownInDefinedShapeOfExistingType extends ConstructorCallStackManipulation {
+        private final MethodDescription.InDefinedShape ctor;
+        private final TypeDescription typeDescription;
+
+        public KnownInDefinedShapeOfExistingType(InDefinedShape ctor) {
+            this(ctor, new ArrayList<StackManipulation>());
+        }
+
+        public KnownInDefinedShapeOfExistingType(InDefinedShape ctor,
+                                                 StackManipulation... constructorArgumentLoadingOperations) {
+            this(ctor, Arrays.asList(constructorArgumentLoadingOperations));
+        }
+
+        public KnownInDefinedShapeOfExistingType(InDefinedShape ctor,
+                                                 List<StackManipulation> constructorArgumentLoadingOperations) {
+            super(constructorArgumentLoadingOperations);
+            this.ctor = ctor;
+            typeDescription = ctor.getDeclaringType();
+        }
+
+        @Override
+        public TypeDescription determineTypeDescription(Implementation.Context implementationContext) {
+            return typeDescription;
+        }
+
+        @Override
+        public InDefinedShape determineConstructor(TypeDescription typeDescription) {
+            return ctor;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+
+            KnownInDefinedShapeOfExistingType that = (KnownInDefinedShapeOfExistingType) o;
+
+            return ctor.equals(that.ctor);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + ctor.hashCode();
+            return result;
+        }
+    }
+
+    /**
+     * To be used when we need to call a constructor of the instrumented type
+     */
+    public abstract static class OfInstrumentedType extends ConstructorCallStackManipulation {
+
+        public OfInstrumentedType() {
+            super();
+        }
+
+        public OfInstrumentedType(StackManipulation... constructorArgumentLoadingOperations) {
+            super(constructorArgumentLoadingOperations);
+        }
+
+        public OfInstrumentedType(List<StackManipulation> constructorArgumentLoadingOperations) {
+            super(constructorArgumentLoadingOperations);
+        }
+
+        abstract InDefinedShape pickConstructor(
+                MethodList<MethodDescription.InDefinedShape> candidates);
+
+        @Override
+        public TypeDescription determineTypeDescription(Implementation.Context implementationContext) {
+            return implementationContext.getInstrumentedType();
+        }
+
+        @Override
+        public InDefinedShape determineConstructor(TypeDescription typeDescription) {
+            return pickConstructor(typeDescription.getDeclaredMethods().filter(isConstructor()));
+        }
+
+        /**
+         * To be used when we need to call the only constructor of the instrumented type
+         * that takes a single argument
+         */
+        public static class OneArg extends OfInstrumentedType {
+
+            public OneArg() {
+                super();
+            }
+
+            public OneArg(StackManipulation... constructorArgumentLoadingOperations) {
+                super(constructorArgumentLoadingOperations);
+            }
+
+            public OneArg(List<StackManipulation> constructorArgumentLoadingOperations) {
+                super(constructorArgumentLoadingOperations);
+            }
+
+            @Override
+            InDefinedShape pickConstructor(MethodList<InDefinedShape> candidates) {
+                return candidates.filter(takesArguments(1)).getOnly();
+            }
+
+        }
+    }
+
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/GenerateIllegalPropertyCountExceptionStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/GenerateIllegalPropertyCountExceptionStackManipulation.java
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.Throw;
+import net.bytebuddy.implementation.bytecode.constant.TextConstant;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import static net.bytebuddy.description.type.TypeDescription.ForLoadedType;
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+/**
+ * Generates the byte-code needed to throw an IllegalArgumentException with the corresponding helper message
+ */
+public final class GenerateIllegalPropertyCountExceptionStackManipulation implements StackManipulation {
+
+    private final int propertyCount;
+
+    public GenerateIllegalPropertyCountExceptionStackManipulation(int propertyCount) {
+        this.propertyCount = propertyCount;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        final MethodDescription.InDefinedShape messageConstructor =
+                new ForLoadedType(IllegalArgumentException.class)
+                        .getDeclaredMethods()
+                        .filter(isConstructor())
+                        .filter(takesArguments(1))
+                        .filter(takesArgument(0, String.class))
+                        .getOnly();
+
+        final StackManipulation.Compound delegate = new StackManipulation.Compound(
+                new ConstructorCallStackManipulation.KnownInDefinedShapeOfExistingType(
+                        messageConstructor,
+                        new TextConstant("Invalid field index (valid; 0 <= n < "+propertyCount+"): ")
+                ),
+                Throw.INSTANCE
+        );
+
+        return delegate.apply(methodVisitor, implementationContext);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GenerateIllegalPropertyCountExceptionStackManipulation that = (GenerateIllegalPropertyCountExceptionStackManipulation) o;
+
+        return propertyCount == that.propertyCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return propertyCount;
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/JumpStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/JumpStackManipulation.java
@@ -1,0 +1,61 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import static net.bytebuddy.jar.asm.Opcodes.IFNE;
+import static net.bytebuddy.jar.asm.Opcodes.IF_ICMPNE;
+
+public final class JumpStackManipulation implements StackManipulation {
+
+    private final int opcde;
+    private final int stackImpact;
+    private final Label label;
+
+    private JumpStackManipulation(int opcde, int stackImpact, Label label) {
+        this.label = label;
+        this.stackImpact = stackImpact;
+        this.opcde = opcde;
+    }
+
+    public static JumpStackManipulation ifne(Label label) {
+        return new JumpStackManipulation(IFNE, -1, label);
+    }
+
+    public static JumpStackManipulation if_icmpne(Label label) {
+        return new JumpStackManipulation(IF_ICMPNE, -2, label);
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        methodVisitor.visitJumpInsn(opcde, label);
+        return new Size(stackImpact, 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        JumpStackManipulation that = (JumpStackManipulation) o;
+
+        if (opcde != that.opcde) return false;
+        if (stackImpact != that.stackImpact) return false;
+        return label.equals(that.label);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = opcde;
+        result = 31 * result + stackImpact;
+        result = 31 * result + label.hashCode();
+        return result;
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/SimpleExceptionHandler.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/SimpleExceptionHandler.java
@@ -1,0 +1,135 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.dynamic.scaffold.InstrumentedType;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+/**
+ * Provides a simple abstraction for implementing
+ * <pre>
+ * {@code
+ * try {
+ *   //code
+ * } catch(SomeException e) {
+ *   //code
+ * }
+ * }
+ * <pre/>
+ *
+ * exceptionThrowingAppender MUST end with a return statement
+ *
+ * Due to way the JVM handles exceptions, when exceptionHandlerAppender is run,
+ * the exception can be found on the top of the stack
+ */
+public class SimpleExceptionHandler implements Implementation, ByteCodeAppender {
+
+    private final StackManipulation exceptionThrowingAppender;
+    private final StackManipulation exceptionHandlerAppender;
+    private final Class<? extends Exception> exceptionType;
+    private final int newLocalVariablesCount;
+
+    public SimpleExceptionHandler(StackManipulation exceptionThrowingAppender,
+                                  StackManipulation exceptionHandlerAppender,
+                                  Class<? extends Exception> exceptionType,
+                                  int newLocalVariablesCount) {
+        this.exceptionThrowingAppender = exceptionThrowingAppender;
+        this.exceptionHandlerAppender = exceptionHandlerAppender;
+        this.exceptionType = exceptionType;
+        this.newLocalVariablesCount = newLocalVariablesCount;
+    }
+
+    @Override
+    public InstrumentedType prepare(InstrumentedType instrumentedType) {
+        return instrumentedType;
+    }
+
+    @Override
+    public ByteCodeAppender appender(Target implementationTarget) {
+        return this;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor,
+                      Implementation.Context implementationContext,
+                      MethodDescription instrumentedMethod) {
+
+        final Label startTryBlock = new Label();
+        final Label endTryBlock = new Label();
+        final Label startCatchBlock = new Label();
+
+        final StackManipulation preTriggerAppender = preTrigger(startTryBlock, endTryBlock, startCatchBlock);
+        final StackManipulation postTriggerAppender = postTrigger(endTryBlock, startCatchBlock);
+
+        final StackManipulation delegate = new StackManipulation.Compound(
+                preTriggerAppender, exceptionThrowingAppender, postTriggerAppender, exceptionHandlerAppender
+        );
+
+        final StackManipulation.Size operandStackSize = delegate.apply(methodVisitor, implementationContext);
+        return new Size(operandStackSize.getMaximalSize(), instrumentedMethod.getStackSize() + newLocalVariablesCount);
+    }
+
+    private StackManipulation preTrigger(final Label startTryBlock,
+                                         final Label endTryBlock,
+                                         final Label startCatchBlock) {
+        return new StackManipulation() {
+            @Override
+            public boolean isValid() {
+                return true;
+            }
+
+            @Override
+            public Size apply(MethodVisitor mv, Implementation.Context ic) {
+                final String name = exceptionType.getName();
+                mv.visitTryCatchBlock(startTryBlock, endTryBlock, startCatchBlock, name.replace(".", "/"));
+                mv.visitLabel(startTryBlock);
+                return new Size(0,0);
+            }
+        };
+    }
+
+    private StackManipulation postTrigger(final Label endTryBlock, final Label startCatchBlock) {
+        return new StackManipulation() {
+            @Override
+            public boolean isValid() {
+                return true;
+            }
+
+            @Override
+            public Size apply(MethodVisitor mv, Implementation.Context ic) {
+                mv.visitLabel(endTryBlock);
+                // and then do catch block
+                mv.visitLabel(startCatchBlock);
+
+                //although this StackManipulation does not alter the stack on it's own
+                //however when an exception is caught
+                //the exception will be on the top of the stack (being placed there by the JVM)
+                //we need to increment the stack size
+                return new Size(1, 0);
+            }
+        };
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SimpleExceptionHandler that = (SimpleExceptionHandler) o;
+
+        if (!exceptionThrowingAppender.equals(that.exceptionThrowingAppender)) return false;
+        if (!exceptionHandlerAppender.equals(that.exceptionHandlerAppender)) return false;
+        return exceptionType.equals(that.exceptionType);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = exceptionThrowingAppender.hashCode();
+        result = 31 * result + exceptionHandlerAppender.hashCode();
+        result = 31 * result + exceptionType.hashCode();
+        return result;
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/SinglePropStackManipulationSupplier.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/SinglePropStackManipulationSupplier.java
@@ -1,0 +1,8 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+
+public interface SinglePropStackManipulationSupplier<T> {
+
+    StackManipulation supply(T prop);
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/TableSwitchStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/TableSwitchStackManipulation.java
@@ -1,0 +1,49 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import java.util.Arrays;
+
+public final class TableSwitchStackManipulation implements StackManipulation {
+
+    private final Label[] labels;
+    private final Label defaultLabel;
+
+    public TableSwitchStackManipulation(Label[] labels, Label defaultLabel) {
+        this.labels = labels;
+        this.defaultLabel = defaultLabel;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        methodVisitor.visitTableSwitchInsn(0, labels.length - 1, defaultLabel, labels);
+        return new Size(-1, 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TableSwitchStackManipulation that = (TableSwitchStackManipulation) o;
+
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(labels, that.labels)) return false;
+        return defaultLabel.equals(that.defaultLabel);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(labels);
+        result = 31 * result + defaultLabel.hashCode();
+        return result;
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/UsingIfStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/UsingIfStackManipulation.java
@@ -1,0 +1,89 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.constant.IntegerConstant;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides template for a method that invokes an operation on a bean. The method or field
+ * that the operation is performed on is chosen by the supplied index and the resulting bytecode
+ * uses jump to simulate if/then/else statements
+ *
+ * The invocation on the bean is configurable via a {@link SinglePropStackManipulationSupplier}
+ *
+ * One possible bytecode outcome would be:
+ * <pre>
+ * {@code
+ *  if (var2 == 0) {
+ *      varX.setA(var3);
+ *  } else if (var2 == 1) {
+ *      varX.setB(var3);
+ *  } else {
+ *      varX.setC(var3);
+ *  }
+ * }
+ * </pre>
+ *
+ * Another possible bytecode outcome this class could produce would be:
+ * <pre>
+ * {@code
+ *  if (var2 == 0) {
+ *      return varX.getA();
+ *  } else if (var2 == 1) {
+ *      return varX.getB();
+ *  } else {
+ *      return varX.getC();
+ *  }
+ * }
+ * </pre>
+ */
+public class UsingIfStackManipulation<T> extends AbstractPropertyStackManipulation {
+
+    private final List<T> props;
+    private final SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier;
+
+    public UsingIfStackManipulation(LocalVarIndexCalculator localVarIndexCalculator,
+                                    List<T> props,
+                                    SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier) {
+        super(localVarIndexCalculator);
+        this.props = props;
+        this.singlePropStackManipulationSupplier = singlePropStackManipulationSupplier;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        final List<StackManipulation> stackManipulations = new ArrayList<StackManipulation>();
+
+        stackManipulations.add(loadFieldIndexArg());
+
+        Label next = new Label();
+        //check if 'index == 0'
+        stackManipulations.add(JumpStackManipulation.ifne(next));
+
+        //first field accessor
+        stackManipulations.add(singlePropStackManipulationSupplier.supply(props.get(0)));
+
+        //loop to create accessors for the rest of the fields
+        for (int i = 1, end = props.size()-1; i <= end; ++i) {
+            stackManipulations.add(new VisitLabelStackManipulation(next));
+            // No comparison needed for the last entry; assumed to match
+            if (i < end) {
+                next = new Label();
+                stackManipulations.add(loadFieldIndexArg());
+                stackManipulations.add(IntegerConstant.forValue(i));
+                stackManipulations.add(JumpStackManipulation.if_icmpne(next));
+            }
+
+            stackManipulations.add(singlePropStackManipulationSupplier.supply(props.get(i)));
+        }
+
+        final StackManipulation.Compound compound = new StackManipulation.Compound(stackManipulations);
+        return compound.apply(methodVisitor, implementationContext);
+    }
+
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/UsingSwitchStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/UsingSwitchStackManipulation.java
@@ -1,0 +1,93 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides template for a method that invokes an operation on a bean. The method or field
+ * that the operation is performed on is chosen by the supplied index and the resulting bytecode
+ * uses tableswitch to simulate a switch statement
+ *
+ * The invocation on the bean is configurable via a {@link SinglePropStackManipulationSupplier}
+ *
+ * One possible bytecode outcome would be:
+ * <pre>
+ * {@code
+ *   switch(var2) {
+ *   case 0:
+ *      var4.setC(var3);
+ *      return;
+ *   case 1:
+ *      var4.setA(var3);
+ *      return;
+ *   case 2:
+ *      var4.setB(var3);
+ *      return;
+ *   case 3:
+ *      var4.setE(var3);
+ *      return;
+ *   default:
+ * }
+ * }
+ * </pre>
+ *
+ * Another possible bytecode outcome this class could produce would be:
+ * <pre>
+ * {@code
+ *   switch(var2) {
+ *   case 0:
+ *      return var4.getA();
+ *   case 1:
+ *      return var4.getB();
+ *   case 2:
+ *      return var4.getC();
+ *   case 3:
+ *      return var4.getD();
+ *   default:
+ * }
+ * }
+ * </pre>
+ */
+public class UsingSwitchStackManipulation<T> extends AbstractPropertyStackManipulation {
+
+    private final List<T> props;
+    private final SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier;
+
+    public UsingSwitchStackManipulation(LocalVarIndexCalculator localVarIndexCalculator,
+                                        List<T> props,
+                                        SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier) {
+        super(localVarIndexCalculator);
+        this.props = props;
+        this.singlePropStackManipulationSupplier = singlePropStackManipulationSupplier;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        final List<StackManipulation> stackManipulations = new ArrayList<StackManipulation>();
+
+        stackManipulations.add(loadFieldIndexArg());
+
+        final Label[] labels = new Label[props.size()];
+        for (int i = 0, len = labels.length; i < len; ++i) {
+            labels[i] = new Label();
+        }
+        final Label defaultLabel = new Label();
+        stackManipulations.add(new TableSwitchStackManipulation(labels, defaultLabel));
+
+        for (int i = 0, len = labels.length; i < len; ++i) {
+            stackManipulations.add(new VisitLabelStackManipulation(labels[i]));
+            stackManipulations.add(singlePropStackManipulationSupplier.supply(props.get(i)));
+        }
+        stackManipulations.add(new VisitLabelStackManipulation(defaultLabel));
+        // and if no match, generate exception:
+        stackManipulations.add(new GenerateIllegalPropertyCountExceptionStackManipulation(props.size()));
+
+        final StackManipulation.Compound compound = new StackManipulation.Compound(stackManipulations);
+        return compound.apply(methodVisitor, implementationContext);
+    }
+}

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/VisitLabelStackManipulation.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/util/bytebuddy/VisitLabelStackManipulation.java
@@ -1,0 +1,41 @@
+package com.fasterxml.jackson.module.afterburner.util.bytebuddy;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+
+public final class VisitLabelStackManipulation implements StackManipulation {
+
+    private final Label label;
+
+    public VisitLabelStackManipulation(Label label) {
+        this.label = label;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext) {
+        methodVisitor.visitLabel(label);
+        return new Size(0, 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        VisitLabelStackManipulation that = (VisitLabelStackManipulation) o;
+
+        return label.equals(that.label);
+    }
+
+    @Override
+    public int hashCode() {
+        return label.hashCode();
+    }
+}

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestSingleArgCtors.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestSingleArgCtors.java
@@ -8,7 +8,7 @@ public class TestSingleArgCtors extends AfterburnerTestBase
 {
     static class Node {
         public String name;
-        
+
         public int value;
 
         public Node() { }
@@ -19,7 +19,61 @@ public class TestSingleArgCtors extends AfterburnerTestBase
             value = -1;
         }
     }
-    
+
+    static class Node2 {
+        public String name;
+
+        public int value1;
+        public int value2;
+
+        public Node2() { }
+
+        @JsonCreator
+        public Node2(String n) {
+            name = n;
+            value1 = -1;
+            value2 = -2;
+        }
+    }
+
+    static class Node3 {
+        public String name;
+
+        public int value1;
+        public int value2;
+        public int value3;
+
+        public Node3() { }
+
+        @JsonCreator
+        public Node3(String n) {
+            name = n;
+            value1 = -1;
+            value2 = -2;
+            value3 = -3;
+        }
+    }
+
+    static class Node4 {
+        public String name;
+
+        public int value1;
+        public int value2;
+        public int value3;
+        public int value4;
+
+        public Node4() { }
+
+        @JsonCreator
+        public Node4(String n) {
+            name = n;
+            value1 = -1;
+            value2 = -2;
+            value3 = -3;
+            value4 = -4;
+        }
+    }
+
     /*
     /**********************************************************
     /* Test methods
@@ -27,7 +81,7 @@ public class TestSingleArgCtors extends AfterburnerTestBase
      */
 
     private final ObjectMapper MAPPER = newObjectMapper();
-    
+
     public void testSingleStringArgCtor() throws Exception
     {
         Node bean = MAPPER.readValue(quote("Foobar"), Node.class);
@@ -36,4 +90,33 @@ public class TestSingleArgCtors extends AfterburnerTestBase
         assertEquals("Foobar", bean.name);
     }
 
+    public void testSingleStringArgCtor2() throws Exception
+    {
+        Node2 bean = MAPPER.readValue(quote("Foobar"), Node2.class);
+        assertNotNull(bean);
+        assertEquals(-1, bean.value1);
+        assertEquals(-2, bean.value2);
+        assertEquals("Foobar", bean.name);
+    }
+
+    public void testSingleStringArgCtor3() throws Exception
+    {
+        Node3 bean = MAPPER.readValue(quote("Foobar"), Node3.class);
+        assertNotNull(bean);
+        assertEquals(-1, bean.value1);
+        assertEquals(-2, bean.value2);
+        assertEquals(-3, bean.value3);
+        assertEquals("Foobar", bean.name);
+    }
+
+    public void testSingleStringArgCtor4() throws Exception
+    {
+        Node4 bean = MAPPER.readValue(quote("Foobar"), Node4.class);
+        assertNotNull(bean);
+        assertEquals(-1, bean.value1);
+        assertEquals(-2, bean.value2);
+        assertEquals(-3, bean.value3);
+        assertEquals(-4, bean.value4);
+        assertEquals("Foobar", bean.name);
+    }
 }

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestSimpleSerialize.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestSimpleSerialize.java
@@ -1,26 +1,48 @@
 package com.fasterxml.jackson.module.afterburner.ser;
 
-import java.lang.reflect.Field;
-import java.util.Vector;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.afterburner.AfterburnerTestBase;
 
+import java.lang.reflect.Field;
+import java.util.Vector;
+
 public class TestSimpleSerialize extends AfterburnerTestBase
 {
     public enum MyEnum {
         A, B, C;
     }
-    
+
     /* Keep this as package access, since we can't handle private; but
      * public is pretty much always available.
      */
     static class IntBean {
         @JsonProperty("x")
         int getX() { return 123; }
+    }
+
+    static class IntBean2 {
+        @JsonProperty("x")
+        int getX() { return 123; }
+
+        @JsonProperty("y")
+        int getY() { return 456; }
+    }
+
+    static class IntBean4 {
+        @JsonProperty("a")
+        int getA() { return 1; }
+
+        @JsonProperty("b")
+        int getB() { return 2; }
+
+        @JsonProperty("c")
+        int getC() { return 3; }
+
+        @JsonProperty("d")
+        int getD() { return 4; }
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -64,7 +86,7 @@ public class TestSimpleSerialize extends AfterburnerTestBase
     static class EnumBean {
         public MyEnum getEnum() { return MyEnum.B; }
     }
-    
+
     static class IntFieldBean {
         @JsonProperty("intF") int x = 17;
     }
@@ -131,6 +153,26 @@ public class TestSimpleSerialize extends AfterburnerTestBase
         assertEquals("{\"x\":123}", MAPPER.writeValueAsString(new IntBean()));
     }
 
+    public void testIntMethod2() throws Exception {
+        final String json = MAPPER.writeValueAsString(new IntBean2());
+        assertTrue(json.contains("x"));
+        assertTrue(json.contains("123"));
+        assertTrue(json.contains("y"));
+        assertTrue(json.contains("456"));
+    }
+
+    public void testIntMethod4() throws Exception {
+        final String json = MAPPER.writeValueAsString(new IntBean4());
+        assertTrue(json.contains("a"));
+        assertTrue(json.contains("1"));
+        assertTrue(json.contains("b"));
+        assertTrue(json.contains("2"));
+        assertTrue(json.contains("c"));
+        assertTrue(json.contains("3"));
+        assertTrue(json.contains("d"));
+        assertTrue(json.contains("4"));
+    }
+
     public void testNonDefaultIntMethod() throws Exception {
         assertEquals("{}", MAPPER.writeValueAsString(new NonDefaultIntBean()));
         assertEquals("{\"x\":-181}", MAPPER.writeValueAsString(new NonDefaultIntBean(-181)));
@@ -158,7 +200,7 @@ public class TestSimpleSerialize extends AfterburnerTestBase
     /* Test methods, field access
     /**********************************************************************
      */
-    
+
     public void testIntField() throws Exception {
         assertEquals("{\"intF\":17}", MAPPER.writeValueAsString(new IntFieldBean()));
     }
@@ -184,7 +226,7 @@ public class TestSimpleSerialize extends AfterburnerTestBase
     public void testStringField2() throws Exception {
         assertEquals("{\"foo\":\"bar\"}", MAPPER.writeValueAsString(new StringFieldBean()));
     }
-    
+
     public void testObjectField() throws Exception {
         assertEquals("{\"a\":null}", MAPPER.writeValueAsString(new StringsBean()));
     }
@@ -199,7 +241,7 @@ public class TestSimpleSerialize extends AfterburnerTestBase
     /* Test methods, other
     /**********************************************************************
      */
-    
+
     public void testFiveMinuteDoc() throws Exception
     {
         ObjectMapper plainMapper = new ObjectMapper();
@@ -220,7 +262,7 @@ public class TestSimpleSerialize extends AfterburnerTestBase
         ClassLoader cl = getClass().getClassLoader();
         Field declaredField = ClassLoader.class.getDeclaredField("classes");
         declaredField.setAccessible(true);
-        Class<?>[] os = new Class[2048];
+        Class<?>[] os = new Class[3072];
         ((Vector<Class<?>>) declaredField.get(cl)).copyInto(os);
         String expectedClassName = TestSimpleSerialize.class.getCanonicalName()
                 + "$CheckGeneratedSerializerName$Access4JacksonSerializer";


### PR DESCRIPTION
This PR replaces all the parts that contain ASM code-gen logic, with ByteBuddy.

I should note that while replacing the ASM code-gen code with the relevant ByteBuddy code, I tried to encapsulate the common logic and "algorithms" of the various parts into self standing classes that can be composed and reused.

Furthermore, the new code also contains a few minor changes to the generated bytecode in order to remove the following unnecessary instructions:

- When generating code for a single method/field, the index is no longer loaded onto the stack since it's not used
- The IllegalArgumentException is only generated when using the `switch` method. In the case of a single method/field or when the `if` method is used, the exceptions are not generated since it was impossible for control to reach them anyway.
- The bytecode that throws the IllegalArgumentException adds the whole string to the stack and forgoes the use of `StringBuilder`. This is because at the time of the bytecode creation, the whole exception message is already known.

It goes without saying that I am willing to make any changes you deem necessary since I acknowledge that the surface area of the changes is rather large and that I might have missed something and/or not designed/implemented something in the optimal way. 