### PR TITLE
Fix introspector chaining in JaxbAnnotationIntrospector.hasRequiredMarker()

### DIFF
--- a/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
+++ b/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
@@ -441,13 +441,10 @@ public class JaxbAnnotationIntrospector
         if ((attr != null) && attr.required()) {
             return Boolean.TRUE;
         }
-        // 09-Sep-2015, tatu: Not 100% sure that we should ever return `false`
-        //   here (as it blocks calls to secondary introspector), but since that
-        //   was the existing behavior before 2.6, is retained for now.
         if ((elem != null) || (attr != null)) {
-            return null;
+            return Boolean.FALSE;
         }
-        return Boolean.FALSE;
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Let's say I have a property marked with `@JsonProperty(required = true)`. 
I also used `objectMapper.registerModules(ObjectMapper.findModules(classLoader))` to register modules but now the property is not considered "required".

That's because there is a chain of `JaxbAnnotationIntrospector` and `JacksonAnnotationIntrospector` (in this order) and `JaxbAnnotationIntrospector.hasRequiredMarker()` returns `Boolean.FALSE` so `JacksonAnnotationIntrospector` is not called (in `AnnotationIntrospectorPair`).

This PR fixes this case, `JaxbAnnotationIntrospector.hasRequiredMarker()` now returns `null` so property can be processed by subsequent introspector.

This PR also changes that `JaxbAnnotationIntrospector.hasRequiredMarker()` now authoritatively returns `Boolean.FALSE` when annotation is present. This behavior is consistent with `JacksonAnnotationIntrospector`.