### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/afterburner/README.md
+++ b/afterburner/README.md
@@ -7,7 +7,7 @@ Afterburner plugs in using standard `Module` interface.
 Module is considered stable and has been used in production environments since version 2.2.
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-afterburner/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-afterburner/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-afterburner/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-afterburner)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.module/jackson-module-afterburner.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-afterburner)
 
 ## Usage
 

--- a/guice/README.md
+++ b/guice/README.md
@@ -5,7 +5,7 @@ jackson-module-guice
 
 [![Build Status](https://travis-ci.org/FasterXML/jackson-module-guice.svg)](https://travis-ci.org/FasterXML/jackson-module-guice)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-guice/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-guice/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-guice/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-guice)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.module/jackson-module-guice.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-guice)
 
 ## Documentation
 

--- a/jaxb/README.md
+++ b/jaxb/README.md
@@ -7,7 +7,7 @@ It is most often used to make it easier to reuse existing data beans that used w
 
 [![Build Status](https://travis-ci.org/FasterXML/jackson-module-jaxb-annotations.svg)](https://travis-ci.org/FasterXML/jackson-module-jaxb-annotations)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-jaxb-annotations)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.module/jackson-module-jaxb-annotations.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-jaxb-annotations)
 
 
 Module is fully usable, as it is based on earlier "jackson-xc" jar that was part of Jackson distribution in 1.x versions.

--- a/mrbean/README.md
+++ b/mrbean/README.md
@@ -9,7 +9,7 @@ Module is licensed under [Apache License 2.0](http://www.apache.org/licenses/LIC
 ## Status
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-mrbean/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-mrbean/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-mrbean/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-mrbean)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.module/jackson-module-mrbean.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-mrbean)
 
 Module is fully usable, and considered stable.
 

--- a/osgi/README.md
+++ b/osgi/README.md
@@ -8,7 +8,7 @@ Module is licensed under [Apache License 2.0](http://www.apache.org/licenses/LIC
 ## Status
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-osgi/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-osgi/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-osgi/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-osgi)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.module/jackson-module-osgi.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-osgi)
 
 ## Usage
 

--- a/paranamer/README.md
+++ b/paranamer/README.md
@@ -11,7 +11,7 @@ Functionality consists of two `AnnotationIntrospector` implementations:
 Module is considered stable and has been used in production environments since version 2.3.
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-paranamer/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-paranamer/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-paranamer/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-paranamer)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.module/jackson-module-paranamer.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-paranamer)
 
 ## Usage
 


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io