### PR TITLE
JPMS Strictly Named Modules

### DIFF
--- a/afterburner/README.md
+++ b/afterburner/README.md
@@ -31,6 +31,15 @@ For non-Maven use cases, you download jars from [Central Maven repository](http:
 
 Module jar is also a functional OSGi bundle, with proper import/export declarations, so it can be use on OSGi container as is.
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.module.afterburner ```
+
+-----
+
 ### Registering module
 
 To use the the Module in Jackson, simply register it with the ObjectMapper instance:

--- a/afterburner/pom.xml
+++ b/afterburner/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-modules-base</artifactId>
@@ -33,6 +33,21 @@ field access and method calls
 <!--
      <osgi.private>com.fasterxml.jackson.module.afterburner.asm</osgi.private>
 -->
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+         and new language features (diamond pattern) may be used.
+         JDK classes are still loaded dynamically since there isn't much downside
+         (small number of types); this allows use on JDK 6 platforms still (including
+         Android)
+      -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
+
   </properties>
 
   <dependencies>

--- a/afterburner/pom.xml
+++ b/afterburner/pom.xml
@@ -33,21 +33,6 @@ field access and method calls
 <!--
      <osgi.private>com.fasterxml.jackson.module.afterburner.asm</osgi.private>
 -->
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
-
   </properties>
 
   <dependencies>
@@ -87,33 +72,28 @@ field access and method calls
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <!--  We will shade ASM, to simplify deployment, avoid version conflicts -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>org.ow2.asm:asm</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>org.objectweb.asm</pattern>
-                  <shadedPattern>com.fasterxml.jackson.module.afterburner.asm</shadedPattern>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/afterburner/src/moditect/module-info.java
+++ b/afterburner/src/moditect/module-info.java
@@ -1,7 +1,7 @@
 import com.fasterxml.jackson.databind.Module;
 
 module com.fasterxml.jackson.module.afterburner {
-	requires com.fasterxml.jackson.core;
+
 	requires com.fasterxml.jackson.databind;
 	requires java.logging;
 

--- a/afterburner/src/moditect/module-info.java
+++ b/afterburner/src/moditect/module-info.java
@@ -1,0 +1,11 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.module.afterburner {
+	requires com.fasterxml.jackson.core;
+	requires com.fasterxml.jackson.databind;
+	requires java.logging;
+
+	requires static org.objectweb.asm;
+
+	provides Module with com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+}

--- a/guice/README.md
+++ b/guice/README.md
@@ -7,6 +7,15 @@ jackson-module-guice
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-guice/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-guice/)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-guice/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-guice)
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.module.guice ```
+
+-----
+
 ## Documentation
 
 This extension allows Jackson to delegate ObjectMapper creation and value injection to Guice when handling data bindings.

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/FasterXML/jackson-modules-base</url>
 
     <properties>
-        <version.guice>[3.0,5.0)</version.guice>
+        <version.guice>[4.2.2,5.0)</version.guice>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/guice</packageVersion.dir>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -49,6 +49,28 @@
 	<groupId>com.google.code.maven-replacer-plugin</groupId>
 	<artifactId>replacer</artifactId>
       </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 

--- a/guice/src/moditect/module-info.java
+++ b/guice/src/moditect/module-info.java
@@ -1,0 +1,8 @@
+module com.fasterxml.jackson.module.guice {
+	requires com.fasterxml.jackson.core;
+	requires com.fasterxml.jackson.databind;
+	requires java.logging;
+	requires com.google.guice;
+	requires com.fasterxml.jackson.annotation;
+	requires javax.inject;
+}

--- a/guice/src/moditect/module-info.java
+++ b/guice/src/moditect/module-info.java
@@ -1,8 +1,10 @@
 module com.fasterxml.jackson.module.guice {
-	requires com.fasterxml.jackson.core;
+
 	requires com.fasterxml.jackson.databind;
+
 	requires java.logging;
 	requires com.google.guice;
-	requires com.fasterxml.jackson.annotation;
+
 	requires javax.inject;
+
 }

--- a/jaxb/README.md
+++ b/jaxb/README.md
@@ -28,6 +28,17 @@ To use this extension on Maven-based projects, use following dependency:
 
 (or whatever version is most up-to-date at the moment)
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.module.jaxb ```
+
+This module requires JAXB version 2.3 for JPMS
+
+-----
+
 ## Usage
 
 To enable use of JAXB annotations, one must add `JaxbAnnotationIntrospector` provided by this module. There are two ways to do this:

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -19,23 +19,6 @@ data-binding.
    <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/module/jaxb</packageVersion.dir>
     <packageVersion.package>${project.groupId}.jaxb</packageVersion.package>
-
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
-
-
   </properties>
   <dependencies>
     <!-- Extends Jackson core and mapper; minor dep on annotations too (JsonInclude) -->
@@ -67,12 +50,34 @@ data-binding.
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>replacer</artifactId>
       </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 
     <profiles>
         <profile>
-            <id>JPMS</id>
+            <id>jdk11</id>
             <dependencies>
                 <dependency>
                     <groupId>javax.activation</groupId>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -53,7 +53,6 @@ data-binding.
         <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Beta1</version>
             <executions>
                 <execution>
                     <id>add-module-infos</id>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-modules-base</artifactId>
@@ -19,6 +19,23 @@ data-binding.
    <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/module/jaxb</packageVersion.dir>
     <packageVersion.package>${project.groupId}.jaxb</packageVersion.package>
+
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+         and new language features (diamond pattern) may be used.
+         JDK classes are still loaded dynamically since there isn't much downside
+         (small number of types); this allows use on JDK 6 platforms still (including
+         Android)
+      -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
+
+
   </properties>
   <dependencies>
     <!-- Extends Jackson core and mapper; minor dep on annotations too (JsonInclude) -->
@@ -39,7 +56,7 @@ data-binding.
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.2</version>
+        <version>2.3.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -52,4 +69,17 @@ data-binding.
       </plugin>
     </plugins>
   </build>
+
+    <profiles>
+        <profile>
+            <id>JPMS</id>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                    <version>1.2.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/jaxb/src/moditect/module-info.java
+++ b/jaxb/src/moditect/module-info.java
@@ -1,0 +1,15 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.module.jaxb {
+	requires transitive com.fasterxml.jackson.databind;
+	requires transitive com.fasterxml.jackson.annotation;
+
+	requires java.xml;
+
+	requires java.activation;
+	requires java.xml.bind;
+
+	requires static java.desktop;
+
+	provides Module with com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+}

--- a/jaxb/src/moditect/module-info.java
+++ b/jaxb/src/moditect/module-info.java
@@ -2,11 +2,7 @@ import com.fasterxml.jackson.databind.Module;
 
 module com.fasterxml.jackson.module.jaxb {
 	requires transitive com.fasterxml.jackson.databind;
-	requires transitive com.fasterxml.jackson.annotation;
 
-	requires java.xml;
-
-	requires java.activation;
 	requires java.xml.bind;
 
 	requires static java.desktop;

--- a/mrbean/README.md
+++ b/mrbean/README.md
@@ -29,6 +29,15 @@ To use module on Maven-based projects, use following dependency:
 
 (or whatever version is most up-to-date at the moment)
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.module.mrbean ```
+
+-----
+
 ## Usage
 
 ### Registering module

--- a/mrbean/pom.xml
+++ b/mrbean/pom.xml
@@ -83,7 +83,6 @@ ${project.groupId}.mrbean.*;version=${project.version}
         <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Beta1</version>
             <executions>
                 <execution>
                     <id>add-module-infos</id>

--- a/mrbean/pom.xml
+++ b/mrbean/pom.xml
@@ -25,22 +25,6 @@ ${project.groupId}.mrbean.*;version=${project.version}
     </osgi.export>
     <!-- default import definitions should work fine -->
     <osgi.private>org.objectweb.asm.*</osgi.private>
-
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
-
   </properties>
 
   <dependencies>
@@ -96,6 +80,28 @@ ${project.groupId}.mrbean.*;version=${project.version}
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 

--- a/mrbean/pom.xml
+++ b/mrbean/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-modules-base</artifactId>
@@ -25,6 +25,22 @@ ${project.groupId}.mrbean.*;version=${project.version}
     </osgi.export>
     <!-- default import definitions should work fine -->
     <osgi.private>org.objectweb.asm.*</osgi.private>
+
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+         and new language features (diamond pattern) may be used.
+         JDK classes are still loaded dynamically since there isn't much downside
+         (small number of types); this allows use on JDK 6 platforms still (including
+         Android)
+      -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
+
   </properties>
 
   <dependencies>

--- a/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/PackageVersion.java
+++ b/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/PackageVersion.java
@@ -1,0 +1,8 @@
+package com.fasterxml.jackson.module.mrbean;
+
+import com.fasterxml.jackson.core.Version;
+
+public class PackageVersion
+{
+	public static Version VERSION = Version.unknownVersion();
+}

--- a/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/PackageVersion.java
+++ b/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/PackageVersion.java
@@ -1,8 +1,0 @@
-package com.fasterxml.jackson.module.mrbean;
-
-import com.fasterxml.jackson.core.Version;
-
-public class PackageVersion
-{
-	public static Version VERSION = Version.unknownVersion();
-}

--- a/mrbean/src/moditect/module-info.java
+++ b/mrbean/src/moditect/module-info.java
@@ -1,0 +1,8 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.module.mrbean {
+	requires transitive com.fasterxml.jackson.databind;
+	requires org.objectweb.asm;
+
+	provides Module with com.fasterxml.jackson.module.mrbean.MrBeanModule;
+}

--- a/osgi/README.md
+++ b/osgi/README.md
@@ -10,6 +10,15 @@ Module is licensed under [Apache License 2.0](http://www.apache.org/licenses/LIC
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-osgi/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-osgi/)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-osgi/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-osgi)
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.module.osgi ```
+
+-----
+
 ## Usage
 
 For example, imagine a drawing software that persists shapes in JSON documents (on file system, mongodb or orientdb). The _Shape_ object needs a _DrawingService_ that is in charge of drawing shapes.

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,6 +21,22 @@
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/osgi</packageVersion.dir>
         <packageVersion.package>${project.groupId}.osgi</packageVersion.package>
+
+        <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+         and new language features (diamond pattern) may be used.
+         JDK classes are still loaded dynamically since there isn't much downside
+         (small number of types); this allows use on JDK 6 platforms still (including
+         Android)
+      -->
+        <!-- TODO Remove JDK 11 Settings -->
+        <javac.src.version>1.11</javac.src.version>
+        <javac.target.version>1.11</javac.target.version>
+
+        <jdk.version>1.11</jdk.version>
+        <maven.compiler.source>1.11</maven.compiler.source>
+        <maven.compiler.target>1.11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+
     </properties>
 
     <dependencies>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,22 +21,6 @@
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/osgi</packageVersion.dir>
         <packageVersion.package>${project.groupId}.osgi</packageVersion.package>
-
-        <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-        <!-- TODO Remove JDK 11 Settings -->
-        <javac.src.version>1.11</javac.src.version>
-        <javac.target.version>1.11</javac.target.version>
-
-        <jdk.version>1.11</jdk.version>
-        <maven.compiler.source>1.11</maven.compiler.source>
-        <maven.compiler.target>1.11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
-
     </properties>
 
     <dependencies>
@@ -63,6 +47,28 @@
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>replacer</artifactId>
       </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -50,7 +50,6 @@
         <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Beta1</version>
             <executions>
                 <execution>
                     <id>add-module-infos</id>

--- a/osgi/src/main/java/com/fasterxml/jackson/module/osgi/OsgiJacksonModule.java
+++ b/osgi/src/main/java/com/fasterxml/jackson/module/osgi/OsgiJacksonModule.java
@@ -1,10 +1,9 @@
 package com.fasterxml.jackson.module.osgi;
 
-import org.osgi.framework.BundleContext;
-
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.osgi.framework.BundleContext;
 
 /**
  * A Jackson Module to inject OSGI services in deserialized objects.
@@ -18,12 +17,20 @@ public class OsgiJacksonModule extends Module
 {
     private final BundleContext bundleContext;
 
-    public OsgiJacksonModule(BundleContext bundleContext)
+	/**
+	 * SPI Constructor
+	 */
+	public OsgiJacksonModule()
+	{
+		this(null);
+	}
+
+	public OsgiJacksonModule(BundleContext bundleContext)
     {
         this.bundleContext = bundleContext;
     }
-    
-    @Override
+
+	@Override
     public String getModuleName() {
         return getClass().getSimpleName();
     }

--- a/osgi/src/moditect/module-info.java
+++ b/osgi/src/moditect/module-info.java
@@ -1,6 +1,9 @@
 import com.fasterxml.jackson.databind.Module;
 
 module com.fasterxml.jackson.module.osgi {
+
+	exports com.fasterxml.jackson.module.osgi;
+
 	requires org.osgi.core;
 
 	requires transitive com.fasterxml.jackson.core;

--- a/osgi/src/moditect/module-info.java
+++ b/osgi/src/moditect/module-info.java
@@ -1,0 +1,10 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.module.osgi {
+	requires org.osgi.core;
+
+	requires transitive com.fasterxml.jackson.core;
+	requires transitive com.fasterxml.jackson.databind;
+
+	provides Module with com.fasterxml.jackson.module.osgi.OsgiJacksonModule;
+}

--- a/paranamer/README.md
+++ b/paranamer/README.md
@@ -13,6 +13,16 @@ Module is considered stable and has been used in production environments since v
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-paranamer/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.module/jackson-module-paranamer/)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.fasterxml.jackson.module/jackson-module-paranamer/badge.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.module/jackson-module-paranamer)
 
+
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.datatype.jsr310```
+
+-----
+
 ## Usage
 
 Functionality can be used either by directly overriding `AnnotationIntrospector` that `ObjectMapper` uses

--- a/paranamer/pom.xml
+++ b/paranamer/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-modules-base</artifactId>
@@ -23,6 +23,21 @@ to introspect names of constructor (and factory method) parameters.
     -->
     <osgi.export>${project.groupId}.paranamer.*</osgi.export>
     <osgi.private>com.thoughtworks.paranamer.*</osgi.private>
+
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+         and new language features (diamond pattern) may be used.
+         JDK classes are still loaded dynamically since there isn't much downside
+         (small number of types); this allows use on JDK 6 platforms still (including
+         Android)
+      -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -63,6 +78,7 @@ to introspect names of constructor (and factory method) parameters.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
         <configuration>
           <optimize>true</optimize>
           <debug>true</debug>

--- a/paranamer/pom.xml
+++ b/paranamer/pom.xml
@@ -23,21 +23,6 @@ to introspect names of constructor (and factory method) parameters.
     -->
     <osgi.export>${project.groupId}.paranamer.*</osgi.export>
     <osgi.private>com.thoughtworks.paranamer.*</osgi.private>
-
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -119,7 +104,59 @@ to introspect names of constructor (and factory method) parameters.
           </execution>
         </executions>
       </plugin>
+       <plugin>
+           <groupId>org.moditect</groupId>
+           <artifactId>moditect-maven-plugin</artifactId>
+           <version>1.0.0.Beta1</version>
+           <executions>
+               <execution>
+                   <id>add-module-infos</id>
+                   <phase>package</phase>
+                   <goals>
+                       <goal>add-module-info</goal>
+                   </goals>
+                   <configuration>
+                       <overwriteExistingFiles>true</overwriteExistingFiles>
+                       <module>
+                           <moduleInfoFile>
+                               src/moditect/module-info.java
+                           </moduleInfoFile>
+                       </module>
+                   </configuration>
+               </execution>
+           </executions>
+       </plugin>
    </plugins>
   </build>
+
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <id>add-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/moditect/</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/paranamer/src/moditect/module-info.java
+++ b/paranamer/src/moditect/module-info.java
@@ -1,0 +1,9 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.module.paranamer {
+	requires com.fasterxml.jackson.databind;
+	requires paranamer;
+	requires com.fasterxml.jackson.core;
+
+	provides Module with com.fasterxml.jackson.module.paranamer.ParanamerModule;
+}

--- a/paranamer/src/moditect/module-info.java
+++ b/paranamer/src/moditect/module-info.java
@@ -1,9 +1,9 @@
 import com.fasterxml.jackson.databind.Module;
 
 module com.fasterxml.jackson.module.paranamer {
+
 	requires com.fasterxml.jackson.databind;
 	requires paranamer;
-	requires com.fasterxml.jackson.core;
 
 	provides Module with com.fasterxml.jackson.module.paranamer.ParanamerModule;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-base</artifactId>
-    <version>2.9.7</version>
+      <version>2.9.8-SNAPSHOT</version>
   </parent>
   <groupId>com.fasterxml.jackson.module</groupId>
   <artifactId>jackson-modules-base</artifactId>
@@ -27,7 +27,7 @@ not datatype, data format, or JAX-RS provider modules.
   <scm>
     <connection>scm:git:git@github.com:FasterXML/jackson-modules-base.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-modules-base.git</developerConnection>
-    <url>http://github.com/FasterXML/jackson-modules-base</url>    
+      <url>http://github.com/FasterXML/jackson-modules-base</url>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>
@@ -36,7 +36,9 @@ not datatype, data format, or JAX-RS provider modules.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.asm>5.2</version.asm>
+      <version.asm>7.0</version.asm>
+
+
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,28 @@ not datatype, data format, or JAX-RS provider modules.
             </excludes>
           </configuration>
 	</plugin>
+          <plugin>
+              <groupId>org.moditect</groupId>
+              <artifactId>moditect-maven-plugin</artifactId>
+              <version>1.0.0.Beta1</version>
+              <executions>
+                  <execution>
+                      <id>add-module-infos</id>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>add-module-info</goal>
+                      </goals>
+                      <configuration>
+                          <overwriteExistingFiles>true</overwriteExistingFiles>
+                          <module>
+                              <moduleInfoFile>
+                                  src/moditect/module-info.java
+                              </moduleInfoFile>
+                          </module>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@ not datatype, data format, or JAX-RS provider modules.
           <plugin>
               <groupId>org.moditect</groupId>
               <artifactId>moditect-maven-plugin</artifactId>
-              <version>1.0.0.Beta1</version>
               <executions>
                   <execution>
                       <id>add-module-infos</id>


### PR DESCRIPTION
* JAXB Bump to 2.3.0
* Guice Minimum set to 4.2.2 for JPMS
* JSON Setter - couldn't find merge annotation method on branch 2.9
* JPMS Strictly Named Modules with Hard Exports ONLY

* ASM to 7.0
* Maven Compiler to 3.8.0

JPMS Considerations
===================
For Private/Protected Field Scanning, The required package should open to com.fasterxml.jackson.databind.
This is how it currently works with automatic module naming, but it is now strictly enforced