### PR TITLE
upgrade ASM and maven-shade-plugin to JDK 11 ready versions

### DIFF
--- a/afterburner/pom.xml
+++ b/afterburner/pom.xml
@@ -77,6 +77,7 @@ field access and method calls
         <!--  We will shade ASM, to simplify deployment, avoid version conflicts -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.shade.plugin}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/mrbean/pom.xml
+++ b/mrbean/pom.xml
@@ -56,6 +56,7 @@ ${project.groupId}.mrbean.*;version=${project.version}
         <!--  We will shade ASM, to simplify deployment, avoid version conflicts -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+          <version>${version.maven.shade.plugin}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/paranamer/pom.xml
+++ b/paranamer/pom.xml
@@ -63,6 +63,7 @@ to introspect names of constructor (and factory method) parameters.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+
         <configuration>
           <optimize>true</optimize>
           <debug>true</debug>
@@ -77,6 +78,7 @@ to introspect names of constructor (and factory method) parameters.
         <!--  We will shade Paranamer, to simplify deployment, avoid version conflicts -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.shade.plugin}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@ not datatype, data format, or JAX-RS provider modules.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.asm>5.2</version.asm>
+    <version.asm>7.0</version.asm>
+    <version.maven.shade.plugin>3.2.1</version.maven.shade.plugin>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Upgraded maven-shade-plugin and ASM to versions that work with both JDK 1.8 and JDK 11
All tests pass on both 1.8 and 11
