### PR TITLE
Fixes #77 - Make the dep on javax.activation optional

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -48,6 +48,7 @@ data-binding.
        <groupId>javax.activation</groupId>
        <artifactId>javax.activation-api</artifactId>
        <version>1.2.0</version>
+       <optional>true</optional>
      </dependency>
   </dependencies>
 


### PR DESCRIPTION
This makes the dep on javax.activation optional. The implication is that, if I don't use DataHandlers then there is no need for javax.activation to be present on the classpath. This is consistent with the comments in [JaxbAnnotationIntrospector#isDataHandler()](https://github.com/FasterXML/jackson-modules-base/blob/master/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java#L666)
