### PR TITLE
Fixes #77 - Make the OSGi metadata consider javax.activation as an optional dependency

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -19,6 +19,8 @@ data-binding.
    <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/module/jaxb</packageVersion.dir>
     <packageVersion.package>${project.groupId}.jaxb</packageVersion.package>
+    <!-- Presence of JAF on the bundle classpath is only necessary when ser/deser'ing javax.a.DataHandlers -->
+    <osgi.import>javax.activation;resolution:=optional,*</osgi.import>
   </properties>
   <dependencies>
     <!-- Extends Jackson core and mapper; minor dep on annotations too (JsonInclude) -->


### PR DESCRIPTION
Takes advantage of the OSGi configuration properties defined in the oss-parent pom.