### PR TITLE
Migrate to Jakarta EE 9

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -22,7 +22,7 @@ data-binding.
     <!-- 22-Mar-2019, tatu: [modules-base#80]: Presence of JAF on the bundle classpath is only necessary
            when ser/deser'ing javax.a.DataHandlers
       -->
-    <osgi.import>javax.activation;resolution:=optional,*</osgi.import>
+    <osgi.import>jakarta.activation;resolution:=optional,*</osgi.import>
 
     <version.jaxb.api>3.0.0-RC3</version.jaxb.api>
     <version.jaxb.impl>3.0.0-M3</version.jaxb.impl>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -24,7 +24,9 @@ data-binding.
       -->
     <osgi.import>javax.activation;resolution:=optional,*</osgi.import>
 
-    <version.jaxb.impl>2.3.2</version.jaxb.impl>
+    <version.jaxb.api>3.0.0-RC3</version.jaxb.api>
+    <version.jaxb.impl>3.0.0-M3</version.jaxb.impl>
+    <version.activation>2.0.0-RC3</version.activation>
   </properties>
   <dependencies>
     <!-- Extends Jackson core and mapper; minor dep on annotations too (JsonInclude) -->
@@ -45,7 +47,7 @@ data-binding.
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>${version.jaxb.impl}</version>
+      <version>${version.jaxb.api}</version>
     </dependency>
     <!-- 05-May-2019, tatu: As per #111, looks like we actually need this
          flavor of activation API...
@@ -53,7 +55,7 @@ data-binding.
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
-      <version>1.2.1</version>
+      <version>${version.activation}</version>
     </dependency>
 
     <!-- may also need JAXB impl for tests -->

--- a/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/AdapterConverter.java
+++ b/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/AdapterConverter.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;

--- a/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
+++ b/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
@@ -5,9 +5,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
 
-import javax.xml.bind.*;
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.*;
+import jakarta.xml.bind.*;
+import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.adapters.*;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.*;
@@ -32,16 +32,16 @@ import com.fasterxml.jackson.module.jaxb.ser.DataHandlerJsonSerializer;
  * <ul>
  * <li>{@link XmlAnyAttribute} not yet used (as of 1.5) but may be in future (as an alias for @JsonAnySetter?)
  * <li>{@link XmlAnyElement} not yet used, may be as per [JACKSON-253]
- * <li>{@link javax.xml.bind.annotation.XmlAttachmentRef}: JSON does not support external attachments
+ * <li>{@link jakarta.xml.bind.annotation.XmlAttachmentRef}: JSON does not support external attachments
  * <li>{@link XmlElementDecl}
  * <li>{@link XmlElementRefs} because Jackson doesn't have any support for 'named' collection items -- however,
  *    this may become partially supported as per [JACKSON-253].
- * <li>{@link javax.xml.bind.annotation.XmlInlineBinaryData} since the underlying concepts
+ * <li>{@link jakarta.xml.bind.annotation.XmlInlineBinaryData} since the underlying concepts
  *    (like XOP) do not exist in JSON -- Jackson will always use inline base64 encoding as the method
- * <li>{@link javax.xml.bind.annotation.XmlList} because JSON does not have (or necessarily need)
+ * <li>{@link jakarta.xml.bind.annotation.XmlList} because JSON does not have (or necessarily need)
  *    method of serializing list of values as space-separated Strings
- * <li>{@link javax.xml.bind.annotation.XmlMimeType}
- * <li>{@link javax.xml.bind.annotation.XmlMixed} since JSON has no concept of mixed content
+ * <li>{@link jakarta.xml.bind.annotation.XmlMimeType}
+ * <li>{@link jakarta.xml.bind.annotation.XmlMixed} since JSON has no concept of mixed content
  * <li>{@link XmlRegistry}
  * <li>{@link XmlSchema} not used, unlikely to be used
  * <li>{@link XmlSchemaType} not used, unlikely to be used
@@ -664,16 +664,16 @@ public class JaxbAnnotationIntrospector
     }
 
     /**
-     * Determines whether the type is assignable to class javax.activation.DataHandler without requiring that class
+     * Determines whether the type is assignable to class jakarta.activation.DataHandler without requiring that class
      * to be on the classpath.
      *
      * @param type The type.
-     * @return Whether the type is assignable to class javax.activation.DataHandler
+     * @return Whether the type is assignable to class jakarta.activation.DataHandler
      */
     private boolean isDataHandler(Class<?> type)
     {
         return type != null && (Object.class != type)
-               && (("javax.activation.DataHandler".equals(type.getName()) || isDataHandler(type.getSuperclass())));
+               && (("jakarta.activation.DataHandler".equals(type.getName()) || isDataHandler(type.getSuperclass())));
     }
 
     @Override

--- a/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/deser/DataHandlerJsonDeserializer.java
+++ b/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/deser/DataHandlerJsonDeserializer.java
@@ -5,8 +5,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/ser/DataHandlerJsonSerializer.java
+++ b/jaxb/src/main/java/com/fasterxml/jackson/module/jaxb/ser/DataHandlerJsonSerializer.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import javax.activation.DataHandler;
+import jakarta.activation.DataHandler;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.JavaType;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/MapAdapter.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/MapAdapter.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.adapters;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 
 import java.util.HashMap;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdaptedMapType.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdaptedMapType.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.module.jaxb.adapters;
 import java.io.*;
 import java.util.*;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdapters.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdapters.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.module.jaxb.adapters;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;
@@ -77,7 +77,7 @@ public class TestAdapters extends BaseJaxbTest
         
         @Override
         public Calendar unmarshal(String value) {
-            return (javax.xml.bind.DatatypeConverter.parseDateTime(value));
+            return (jakarta.xml.bind.DatatypeConverter.parseDateTime(value));
         }
     
         @Override
@@ -85,7 +85,7 @@ public class TestAdapters extends BaseJaxbTest
             if (value == null) {
                 return null;
             }
-            return (javax.xml.bind.DatatypeConverter.printDateTime(value));
+            return (jakarta.xml.bind.DatatypeConverter.printDateTime(value));
         }
     }
     
@@ -111,7 +111,7 @@ public class TestAdapters extends BaseJaxbTest
     public static class Adapter1 extends XmlAdapter<String, Long> {
         @Override
         public Long unmarshal(String value) {
-            return ((long) javax.xml.bind.DatatypeConverter.parseLong(value));
+            return ((long) jakarta.xml.bind.DatatypeConverter.parseLong(value));
         }
 
         @Override
@@ -119,7 +119,7 @@ public class TestAdapters extends BaseJaxbTest
             if (value == null) {
                 return null;
             }
-            return (javax.xml.bind.DatatypeConverter.printLong((long) (long) value));
+            return (jakarta.xml.bind.DatatypeConverter.printLong((long) (long) value));
         }   
     }    
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdaptersForContainers.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdaptersForContainers.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.module.jaxb.adapters;
 import java.util.*;
 import java.util.Map.Entry;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.*;
+import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.adapters.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestIdentityAdapters.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestIdentityAdapters.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.jaxb.adapters;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/failing/TestUnwrapping.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/failing/TestUnwrapping.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.failing;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/failing/TestXmlID3.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/failing/TestXmlID3.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.module.jaxb.failing;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlID;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.id;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID2.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID2.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.id;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestAccessType.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestAccessType.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.module.jaxb.introspect;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestAnnotationPriority.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestAnnotationPriority.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.introspect;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestIntrospectorPair.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestIntrospectorPair.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.introspect;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestJaxbAnnotationIntrospector.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestJaxbAnnotationIntrospector.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.module.jaxb.introspect;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.namespace.QName;
 
 import com.fasterxml.jackson.databind.*;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestJaxbAutoDetect.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestJaxbAutoDetect.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.math.BigDecimal;
 import java.util.Map;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestJaxbFieldAccess.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestJaxbFieldAccess.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.introspect;
 
 import java.io.IOException;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestPropertyOrdering.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestPropertyOrdering.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.introspect;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestPropertyVisibility.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestPropertyVisibility.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.introspect;
 
 import java.io.IOException;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.*;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestXmlValue.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestXmlValue.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.introspect;
 
 import java.io.IOException;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.*;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestElementWrapper.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestElementWrapper.java
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.module.jaxb.misc;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestEnums.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestEnums.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.misc;
 
-import javax.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnum;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestJaxbNullProperties.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestJaxbNullProperties.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.jaxb.misc;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestRootName.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestRootName.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.misc;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestSerializationInclusion.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestSerializationInclusion.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.misc;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestXmlAnyElementWithElementRef.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/TestXmlAnyElementWithElementRef.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.misc;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/package-info.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/misc/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Package info can be used to add "package annotations", so here we are...
  */
-@javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters({
-  @javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter(
+@jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapters({
+  @jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter(
     type = javax.xml.namespace.QName.class,
     value = com.fasterxml.jackson.module.jaxb.introspect.TestJaxbAnnotationIntrospector.QNameAdapter.class
   )

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/PolymorpicTestBase.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/PolymorpicTestBase.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.types;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestCyclicTypes.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestCyclicTypes.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.types;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbPolymorphic.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbPolymorphic.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.types;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbPolymorphicLists.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbPolymorphicLists.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.types;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbPolymorphicMaps.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbPolymorphicMaps.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.types;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbTypeCoercion1023.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbTypeCoercion1023.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.jaxb.types;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;

--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbTypes.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/types/TestJaxbTypes.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.jaxb.types;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;


### PR DESCRIPTION
Jakarta EE 9 platform renames all the "old" namespaces from javax.* to jakarta.*. This pull request performs this migration so that when Jacakrta EE 9 is released in [June 2020](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan#proposed-progress-reviews) it will be compatible.

I ran mvn test with _no_* failures and travis builds [did not fail](https://travis-ci.com/github/tamersaadeh/jackson-modules-base).

Note 1: this is completely incompatible with the old namespace, so probably the major version of the library should be bumped.
Note 2: currently depends on pre-released versions of the JAXB specification (RC3). This can be updated when the final version is released.

*: a couple of the afterburner tests failed, but I haven't modified that module and I'm not exactly sure how to debug that.