### PR TITLE
Fix detection of inherited default method in Java 8+ interface

### DIFF
--- a/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/BeanBuilder.java
+++ b/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/BeanBuilder.java
@@ -176,16 +176,28 @@ public class BeanBuilder
     {
         final String name = m0.getName();
         final Class<?>[] argTypes = m0.getParameterTypes();
+        try {
+            // getMethod returns the most-specific method implementation, for public methods only (which is any method in an interface)
+            Method effectiveMethod = implementedType.getRawClass().getMethod(name, argTypes);
+            if (BeanUtil.isConcrete(effectiveMethod)) {
+                return true;
+            }
+        } catch (NoSuchMethodException e) {
+            // method must be non-public, fallback to using getDeclaredMethod
+        }
+
         for (JavaType curr = implementedType; (curr != null) && !curr.isJavaLangObject();
                 curr = curr.getSuperClass()) {
             // 29-Nov-2015, tatu: Avoiding exceptions would be good, so would linear scan
             //    be better here?
             try {
                 Method effectiveMethod = curr.getRawClass().getDeclaredMethod(name, argTypes);
-                if (effectiveMethod != null && BeanUtil.isConcrete(effectiveMethod)) {
+                if (BeanUtil.isConcrete(effectiveMethod)) {
                     return true;
                 }
-            } catch (NoSuchMethodException e) { }
+            } catch (NoSuchMethodException e) {
+                // method must exist on a superclass, continue searching...
+            }
         }
         return false;
     }
@@ -240,7 +252,7 @@ public class BeanBuilder
         Class<?> rt = m.getReturnType();
         return (rt == Boolean.class || rt == Boolean.TYPE);
     }
-    
+
     /*
     /**********************************************************
     /* Internal methods, bytecode generation
@@ -288,7 +300,7 @@ public class BeanBuilder
     /* Internal methods, other
     /**********************************************************
      */
-    
+
     protected String decap(String name) {
         char c = name.charAt(0);
         if (name.length() > 1

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClasses.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClasses.java
@@ -24,7 +24,7 @@ public class TestAbstractClasses
 
         // also verify non-public methods
         protected abstract String getZ();
-        private Object customMethod() { return new Object(); }
+        private String customMethod() { return "Private methods rock!"; }
     }
 
     /*
@@ -42,6 +42,6 @@ public class TestAbstractClasses
         assertEquals(13, bean.y);
         assertEquals("Foo!", bean.getFoo());
         assertEquals("def", bean.getZ());
-        assertNotNull(bean.customMethod());
+        assertEquals("Private methods rock!", bean.customMethod());
     }
 }

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClasses.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClasses.java
@@ -16,11 +16,15 @@ public class TestAbstractClasses
         int y;
 
         protected Bean() { }
-        
+
         public abstract String getX();
 
         public String getFoo() { return "Foo!"; }
         public void setY(int value) { y = value; }
+
+        // also verify non-public methods
+        protected abstract String getZ();
+        private Object customMethod() { return new Object(); }
     }
 
     /*
@@ -32,10 +36,12 @@ public class TestAbstractClasses
     public void testSimpleInteface() throws Exception
     {
         ObjectMapper mapper = newMrBeanMapper();
-        Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13 }", Bean.class);
+        Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", Bean.class);
         assertNotNull(bean);
         assertEquals("abc", bean.getX());
         assertEquals(13, bean.y);
         assertEquals("Foo!", bean.getFoo());
+        assertEquals("def", bean.getZ());
+        assertNotNull(bean.customMethod());
     }
 }

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -26,12 +26,17 @@ public class TestAbstractClassesWithOverrides
 
         // also verify non-public methods
         protected abstract String getZ();
-        private Object customMethod() { return new Object(); }
+        private Object customMethod() { return protectedAbstractMethod(); }
+        protected abstract Object protectedAbstractMethod();
     }
 
     public abstract static class CoffeeBean extends Bean {
         @Override public String roast(int temperature) {
             return "The coffee beans are roasting at " + temperature + " degrees now, yummy";
+        }
+
+        @Override protected Object protectedAbstractMethod() {
+            return "Private methods invoking protected abstract methods is the bomb!";
         }
     }
 
@@ -59,7 +64,7 @@ public class TestAbstractClassesWithOverrides
         assertEquals(13, bean.y);
         assertEquals("Foo!", bean.getFoo());
         assertEquals("def", bean.getZ());
-        assertNotNull(bean.customMethod());
         assertEquals("The coffee beans are roasting at 123 degrees now, yummy", bean.roast(123));
+        assertEquals("Private methods invoking protected abstract methods is the bomb!", bean.customMethod());
     }
 }

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -16,13 +16,17 @@ public class TestAbstractClassesWithOverrides
         int y;
 
         protected Bean() { }
-        
+
         public abstract String getX();
 
         public abstract String roast(int temperature);
 
         public String getFoo() { return "Foo!"; }
         public void setY(int value) { y = value; }
+
+        // also verify non-public methods
+        protected abstract String getZ();
+        private Object customMethod() { return new Object(); }
     }
 
     public abstract static class CoffeeBean extends Bean {
@@ -43,9 +47,9 @@ public class TestAbstractClassesWithOverrides
     public void testOverrides() throws Exception
     {
         ObjectMapper mapper = newMrBeanMapper();
-        Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13 }", CoffeeBean.class);
+        Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", CoffeeBean.class);
         verifyBean(bean);
-        Bean bean2 = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13 }", PeruvianCoffeeBean.class);
+        Bean bean2 = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", PeruvianCoffeeBean.class);
         verifyBean(bean2);
     }
 
@@ -54,6 +58,8 @@ public class TestAbstractClassesWithOverrides
         assertEquals("abc", bean.getX());
         assertEquals(13, bean.y);
         assertEquals("Foo!", bean.getFoo());
+        assertEquals("def", bean.getZ());
+        assertNotNull(bean.customMethod());
         assertEquals("The coffee beans are roasting at 123 degrees now, yummy", bean.roast(123));
     }
 }

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestSimpleMaterializedInterfaces.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestSimpleMaterializedInterfaces.java
@@ -56,10 +56,18 @@ public class TestSimpleMaterializedInterfaces
         public abstract int getX();
     }
 
-    public interface ExtendedBean extends Bean {
+    public interface OtherInterface {
+        public boolean anyValuePresent();
+    }
+
+    public interface BeanWithDefaultForOtherInterface extends Bean, OtherInterface {
         public default boolean anyValuePresent() {
             return getX() > 0 || getA() != null;
         }
+    }
+
+    public interface BeanWithInheritedDefault extends BeanWithDefaultForOtherInterface {
+        // in this interface, anyValuePresent() is an inherited (rather than declared) concrete method
     }
 
     /*
@@ -177,10 +185,20 @@ public class TestSimpleMaterializedInterfaces
         assertEquals(2, bean.getY());
     }
 
-    public void testDefaultMethods() throws Exception
+    public void testDefaultMethodInInterface() throws Exception
     {
         ObjectMapper mapper = newMrBeanMapper();
-        ExtendedBean bean = mapper.readValue("{\"a\":\"value\",\"x\":123 }", ExtendedBean.class);
+        BeanWithDefaultForOtherInterface bean = mapper.readValue("{\"a\":\"value\",\"x\":123 }", BeanWithDefaultForOtherInterface.class);
+        assertNotNull(bean);
+        assertEquals("value", bean.getA());
+        assertEquals(123, bean.getX());
+        assertTrue(bean.anyValuePresent());
+    }
+
+    public void testInheritedDefaultMethodInInterface() throws Exception
+    {
+        ObjectMapper mapper = newMrBeanMapper();
+        BeanWithInheritedDefault bean = mapper.readValue("{\"a\":\"value\",\"x\":123 }", BeanWithInheritedDefault.class);
         assertNotNull(bean);
         assertEquals("value", bean.getA());
         assertEquals(123, bean.getX());

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestSimpleMaterializedInterfaces.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestSimpleMaterializedInterfaces.java
@@ -28,13 +28,13 @@ public class TestSimpleMaterializedInterfaces
     {
         public int getY();
     }
-    
+
     public interface PartialBean {
         public boolean isOk();
         // and then non-getter/setter one:
         public int foobar();
     }
-    
+
     public interface BeanHolder {
         public Bean getBean();
     }
@@ -55,7 +55,13 @@ public class TestSimpleMaterializedInterfaces
     interface NonPublicBean {
         public abstract int getX();
     }
-    
+
+    public interface ExtendedBean extends Bean {
+        public default boolean anyValuePresent() {
+            return getX() > 0 || getA() != null;
+        }
+    }
+
     /*
     /**********************************************************
     /* Unit tests, low level
@@ -149,8 +155,8 @@ public class TestSimpleMaterializedInterfaces
         assertNotNull(bean);
         assertEquals("b", bean.getA());
         assertEquals(-4, bean.getX());
-    }    
-    
+    }
+
     public void testArrayInterface() throws Exception
     {
         ObjectMapper mapper = newMrBeanMapper();
@@ -170,7 +176,17 @@ public class TestSimpleMaterializedInterfaces
         assertEquals(1, bean.getX());
         assertEquals(2, bean.getY());
     }
-    
+
+    public void testDefaultMethods() throws Exception
+    {
+        ObjectMapper mapper = newMrBeanMapper();
+        ExtendedBean bean = mapper.readValue("{\"a\":\"value\",\"x\":123 }", ExtendedBean.class);
+        assertNotNull(bean);
+        assertEquals("value", bean.getA());
+        assertEquals(123, bean.getX());
+        assertTrue(bean.anyValuePresent());
+    }
+
     /*
     /**********************************************************
     /* Unit tests, higher level, error handling
@@ -210,6 +226,6 @@ public class TestSimpleMaterializedInterfaces
         } catch (JsonMappingException e) {
             verifyException(e, "is not public");
         }
-    }    
-    
+    }
+
 }


### PR DESCRIPTION
## Problem

When the type to materialize extends/implements some interface that has a default method implementation (with a non-bean method name), MrBean will treat the method as if it lacks an implementation.

## Solution

Use Class.getMethod to locate the exact method that the implemented type will utilize, which properly handles this case.
