### PR TITLE
MrBean: Correct handling of re-abstracted methods

### DIFF
--- a/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/BeanBuilder.java
+++ b/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/BeanBuilder.java
@@ -202,9 +202,9 @@ public class BeanBuilder
             //    be better here?
             try {
                 Method effectiveMethod = curr.getRawClass().getDeclaredMethod(name, argTypes);
-                if (BeanUtil.isConcrete(effectiveMethod)) {
-                    return true;
-                }
+
+                // we've found the method, so we can simply check whether it is concrete
+                return BeanUtil.isConcrete(effectiveMethod);
             } catch (NoSuchMethodException e) {
                 // method must exist on a superclass, continue searching...
             }

--- a/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/BeanBuilder.java
+++ b/mrbean/src/main/java/com/fasterxml/jackson/module/mrbean/BeanBuilder.java
@@ -189,9 +189,9 @@ public class BeanBuilder
             // 22-Sep-2020: [modules-base#109]: getMethod returns the most-specific method
             //  implementation, for public methods only (which is any method in an interface)
             Method effectiveMethod = implementedType.getRawClass().getMethod(name, argTypes);
-            if (BeanUtil.isConcrete(effectiveMethod)) {
-                return true;
-            }
+
+            // we've found the method, so we can simply check whether it is concrete
+            return BeanUtil.isConcrete(effectiveMethod);
         } catch (NoSuchMethodException e) {
             // method must be non-public, fallback to using getDeclaredMethod
         }

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.mrbean;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestAbstractClassesWithOverrides
@@ -47,6 +48,11 @@ public class TestAbstractClassesWithOverrides
         @Override public abstract String toString();
     }
 
+    public abstract static class UnroastableCoffeeBean extends CoffeeBean
+    {
+        @Override public abstract String roast(int temperature);
+    }
+
     public abstract static class CoffeeBeanWithVariableFoo extends CoffeeBean
     {
         @Override public abstract String getFoo();
@@ -82,8 +88,17 @@ public class TestAbstractClassesWithOverrides
         verifyBean(bean);
         try {
             assertNotNull(bean.toString());
+            fail("Should not pass");
         } catch (UnsupportedOperationException e) {
             verifyException(e, "Unimplemented method 'toString'");
+        }
+
+        Bean unroastableBean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", UnroastableCoffeeBean.class);
+        try {
+            unroastableBean.roast(123);
+            fail("Should not pass");
+        } catch (UnsupportedOperationException e) {
+            verifyException(e, "Unimplemented method 'roast'");
         }
 
         // Ensure that the re-abstracted method will read "foo" from the JSON

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -43,6 +43,15 @@ public class TestAbstractClassesWithOverrides
 
     public abstract static class PeruvianCoffeeBean extends CoffeeBean {}
 
+    /*
+     * Test classes where some concrete method has been re-"abstract"-ed
+     */
+
+    public abstract static class CoffeeBeanWithVariableFoo extends CoffeeBean
+    {
+        @Override public abstract String getFoo();
+    }
+
     public abstract static class StringlessCoffeeBean extends CoffeeBean
     {
         @Override public abstract String toString();
@@ -53,9 +62,9 @@ public class TestAbstractClassesWithOverrides
         @Override public abstract String roast(int temperature);
     }
 
-    public abstract static class CoffeeBeanWithVariableFoo extends CoffeeBean
+    public abstract static class CoffeeBeanLackingPublicMethod extends CoffeeBean
     {
-        @Override public abstract String getFoo();
+        @Override protected abstract Object protectedAbstractMethod();
     }
 
 
@@ -102,6 +111,14 @@ public class TestAbstractClassesWithOverrides
         } catch (UnsupportedOperationException e) {
             verifyException(e, "Unimplemented method 'roast'");
         }
+
+        Bean beanLackingNonPublicMethod = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", CoffeeBeanLackingPublicMethod.class);
+        try {
+            beanLackingNonPublicMethod.customMethod();
+            fail("Should not pass");
+        } catch (UnsupportedOperationException e) {
+            verifyException(e, "Unimplemented method 'protectedAbstractMethod'");
+        }
     }
 
     // Ensures that the re-abstracted method will read "foo" from the JSON, regardless of the FAIL_ON_UNMATERIALIZED_METHOD setting
@@ -134,6 +151,13 @@ public class TestAbstractClassesWithOverrides
             fail("Should not pass");
         } catch (JsonMappingException e) {
             verifyException(e, "Unrecognized abstract method 'roast'");
+        }
+
+        try {
+            mapper.readValue("{}", CoffeeBeanLackingPublicMethod.class);
+            fail("Should not pass");
+        } catch (JsonMappingException e) {
+            verifyException(e, "Unrecognized abstract method 'protectedAbstractMethod'");
         }
     }
 

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -42,6 +42,11 @@ public class TestAbstractClassesWithOverrides
 
     public abstract static class PeruvianCoffeeBean extends CoffeeBean {}
 
+    public abstract static class StringlessCoffeeBean extends CoffeeBean
+    {
+        @Override public abstract String toString();
+    }
+
 
     /*
     /**********************************************************
@@ -51,14 +56,26 @@ public class TestAbstractClassesWithOverrides
 
     public void testOverrides() throws Exception
     {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new MrBeanModule());
+        ObjectMapper mapper = newMrBeanMapper();
 
         Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", CoffeeBean.class);
         verifyBean(bean);
 
         Bean bean2 = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", PeruvianCoffeeBean.class);
         verifyBean(bean2);
+    }
+
+    public void testReAbstractedMethods() throws Exception
+    {
+        ObjectMapper mapper = newMrBeanMapper();
+
+        Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", StringlessCoffeeBean.class);
+        verifyBean(bean);
+        try {
+            assertNotNull(bean.toString());
+        } catch (UnsupportedOperationException e) {
+            verifyException(e, "Unimplemented method 'toString'");
+        }
     }
 
     private void verifyBean(Bean bean) {

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -47,6 +47,11 @@ public class TestAbstractClassesWithOverrides
         @Override public abstract String toString();
     }
 
+    public abstract static class CoffeeBeanWithVariableFoo extends CoffeeBean
+    {
+        @Override public abstract String getFoo();
+    }
+
 
     /*
     /**********************************************************
@@ -76,6 +81,12 @@ public class TestAbstractClassesWithOverrides
         } catch (UnsupportedOperationException e) {
             verifyException(e, "Unimplemented method 'toString'");
         }
+
+        // Ensure that the re-abstracted method will read "foo" from the JSON
+        Bean beanWithNoFoo = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", CoffeeBeanWithVariableFoo.class);
+        assertNull(beanWithNoFoo.getFoo());
+        Bean beanWithOtherFoo = mapper.readValue("{ \"foo\": \"Another Foo!\", \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", CoffeeBeanWithVariableFoo.class);
+        assertEquals("Another Foo!", beanWithOtherFoo.getFoo());
     }
 
     private void verifyBean(Bean bean) {

--- a/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
+++ b/mrbean/src/test/java/com/fasterxml/jackson/module/mrbean/TestAbstractClassesWithOverrides.java
@@ -72,7 +72,11 @@ public class TestAbstractClassesWithOverrides
 
     public void testReAbstractedMethods() throws Exception
     {
-        ObjectMapper mapper = newMrBeanMapper();
+        AbstractTypeMaterializer mat = new AbstractTypeMaterializer();
+        // ensure that we will only get deferred error methods
+        mat.disable(AbstractTypeMaterializer.Feature.FAIL_ON_UNMATERIALIZED_METHOD);
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new MrBeanModule(mat));
 
         Bean bean = mapper.readValue("{ \"x\" : \"abc\", \"y\" : 13, \"z\" : \"def\" }", StringlessCoffeeBean.class);
         verifyBean(bean);


### PR DESCRIPTION
This builds on #109 to verify and fix the behavior of checking re-abstracted methods for concreteness.

### Problem

When searching for a concrete override, the existing logic will skip over methods in subclasses that are marked abstract.  If such a method is an override for a concrete method in a parent class, then the logic will incorrectly search the parent class where it will find the concrete method and it will incorrectly return true from `hasConcreteOverride`.  

This behavior has the following undesirable outcomes, depending on the `FAIL_ON_UNMATERIALIZED_METHOD` setting:

1. When disabled, then subsequent invocation of the re-abstracted method will throw an AbstractMethodError, rather than an UnsupportedOperationException.
2. When enabled, then the re-abstracted method will incorrectly NOT fail during materialization.

### Solution

Once we locate the matching method, we can simply return whether that method is concrete.  

This works because our search process always locates the most-specific method:

* If the method is public, then it is guaranteed to be returned by `getMethod`.
* If the method is non-public, then our search process starts at the implemented type, and traverses linearly up the *class* hierarchy.
* Also, it is not possible for a public method to be overridden by a non-public method.

### Verification

I've added unit tests to cover each of the cases:

* Reabstracted method from java.lang.Object
* Reabstracted bean property method
* Reabstracted public custom method
* Reabstracted non-public custom method