### PR TITLE
Module-Info Enhancements - Support JAXB for Jakarta Release

### DIFF
--- a/guice/src/moditect/module-info.java
+++ b/guice/src/moditect/module-info.java
@@ -1,13 +1,16 @@
-// Generated 14-Mar-2019 using Moditect maven plugin
-
 module com.fasterxml.jackson.module.guice {
-    requires javax.inject;
+    //Sun/Oracle implementation
+    requires static javax.inject;
+    //Jakarta Reference Implementation
+    requires static jakarta.inject;
 
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
+
     requires com.google.guice;
 
     exports com.fasterxml.jackson.module.guice;
 
+    //NOTE : Don't auto provide jackson guice module as some may want to bind their own ObjectMapper?
 }

--- a/jaxb/src/moditect/module-info.java
+++ b/jaxb/src/moditect/module-info.java
@@ -1,13 +1,14 @@
-// Manually composed on 14-Mar-2019 -- Moditect maven plugin failed to generate
-
 module com.fasterxml.jackson.module.jaxb {
     requires java.logging;
     requires java.xml;
     requires java.xml.bind;
+    //
     // This is for `BeanIntrospector`... should do away with (only need "Introspector.decapitalize")
     requires java.desktop;
     // Needed for JDK9+, but optionally only
     requires static java.activation;
+    // Jakarta Release
+    requires static jakarta.activation;
 
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;


### PR DESCRIPTION
Module-Info Enhancements - Support JAXB for Jakarta Release

https://github.com/FasterXML/jackson-databind/issues/2910

Support the namespaces specified for JAXB in Jakarta, as well as make activation dependent on the client implementation for javax or jakarta