### PR TITLE
fix #141: Avoid attempting to optimize varargs methods

### DIFF
--- a/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/deser/CreatorOptimizer.java
+++ b/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/deser/CreatorOptimizer.java
@@ -107,7 +107,10 @@ public class CreatorOptimizer
             Stream.of(element)
                 .filter(Constructor.class::isInstance)
                 .map(Constructor.class::cast)
-                .filter(c -> !Modifier.isPrivate(c.getModifiers()))
+                .filter(c -> !Modifier.isPrivate(c.getModifiers())
+                        // 07-Jul-2021, ckozak: modules-base#141Avoid attempting to optimize varargs
+                        // methods due to class-cast edge cases
+                        && !c.isVarArgs())
                 .flatMap(t -> {
                     try {
                         return Stream.of(_lookup.unreflectConstructor(t));
@@ -120,7 +123,10 @@ public class CreatorOptimizer
                 .map(Method.class::cast)
                 .filter(m -> {
                     int mods = m.getModifiers();
-                    return Modifier.isStatic(mods) && !Modifier.isPrivate(mods);
+                    return Modifier.isStatic(mods) && !Modifier.isPrivate(mods)
+                            // 07-Jul-2021, ckozak: modules-base#141Avoid attempting to optimize varargs
+                            // methods due to class-cast edge cases
+                            && !m.isVarArgs();
                 })
                 .flatMap(t -> {
                     try {

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/DoubleArrayDeserTest.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/DoubleArrayDeserTest.java
@@ -1,0 +1,31 @@
+package com.fasterxml.jackson.module.blackbird.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
+
+public class DoubleArrayDeserTest extends BlackbirdTestBase
+{
+    static class Foo141 {
+        @JsonProperty("bar")
+        double[] bar;
+
+        @JsonCreator
+        public Foo141(@JsonProperty("bar") double[] bar) {
+          this.bar = bar;
+        }
+    }
+
+    private final ObjectMapper MAPPER = newObjectMapper();
+
+    public void testDoubleArrayViaCreator()
+    {
+        Foo141 foo = new Foo141(new double[] { 2.0, 0.25 });
+        String serialized = MAPPER.writeValueAsString(foo);
+        Foo141 foo2 = MAPPER.readValue(serialized, Foo141.class);
+
+        assertEquals(2, foo2.bar.length);
+        assertEquals(0.25, foo2.bar[1]);
+    }
+}

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/DoubleVarArgsDeser141Test.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/DoubleVarArgsDeser141Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.blackbird.failing;
+package com.fasterxml.jackson.module.blackbird.deser;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
 
 // [modules-base#141]
-public class DoubleArrayDeser141Test extends BlackbirdTestBase
+public class DoubleVarArgsDeser141Test extends BlackbirdTestBase
 {
     // [modules-base#141]
     static class Foo141 {

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/ObjectArrayDeserTest.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/ObjectArrayDeserTest.java
@@ -1,0 +1,45 @@
+package com.fasterxml.jackson.module.blackbird.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ObjectArrayDeserTest extends BlackbirdTestBase
+{
+    static class Bar {
+        @JsonProperty("baz")
+        String baz;
+
+        @JsonCreator
+        public Bar(@JsonProperty("baz") String baz) {
+            this.baz = baz;
+        }
+    }
+
+    static class Foo141 {
+        @JsonProperty("bar")
+        List<Bar> bar;
+
+        @JsonCreator
+        public Foo141(@JsonProperty("bar") Bar[] bar) {
+          this.bar = Arrays.asList(bar);
+        }
+    }
+
+    private final ObjectMapper MAPPER = newObjectMapper();
+
+    public void testDoubleArrayViaCreator()
+    {
+        Foo141 foo = new Foo141(new Bar[] {new Bar("a"), new Bar("b")});
+        String serialized = MAPPER.writeValueAsString(foo);
+        Foo141 foo2 = MAPPER.readValue(serialized, Foo141.class);
+
+        assertEquals(2, foo2.bar.size());
+        assertEquals("a", foo2.bar.get(0).baz);
+        assertEquals("b", foo2.bar.get(1).baz);
+    }
+}

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/ObjectVarArgsDeser141Test.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/ObjectVarArgsDeser141Test.java
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.module.blackbird.deser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
+
+import java.util.Arrays;
+import java.util.List;
+
+// [modules-base#141]
+public class ObjectVarArgsDeser141Test extends BlackbirdTestBase
+{
+    static class Bar {
+        @JsonProperty("baz")
+        String baz;
+
+        @JsonCreator
+        public Bar(@JsonProperty("baz") String baz) {
+            this.baz = baz;
+        }
+    }
+    // [modules-base#141]
+    static class Foo141 {
+        @JsonProperty("bar")
+        List<Bar> bar;
+
+        @JsonCreator
+        public Foo141(@JsonProperty("bar") Bar... bar) {
+          this.bar = Arrays.asList(bar);
+        }
+    }
+
+    private final ObjectMapper MAPPER = newObjectMapper();
+
+    // [modules-base#141]
+    public void testDoubleArrayViaCreator()
+    {
+        Foo141 foo = new Foo141(new Bar("a"), new Bar("b"));
+        String serialized = MAPPER.writeValueAsString(foo);
+        Foo141 foo2 = MAPPER.readValue(serialized, Foo141.class);
+
+        assertEquals(2, foo2.bar.size());
+        assertEquals("a", foo2.bar.get(0).baz);
+        assertEquals("b", foo2.bar.get(1).baz);
+    }
+}


### PR DESCRIPTION
I've added additional coverage for non-primitive values (which also failed prior to the fix) and duplicated the tests to cover standard arrays in addition to varargs. Only vararg methods failed the test, standard array arguments were, and still are, optimized.