### PR TITLE
Fix 14 flaky tests in afterburner and blackbird module

### DIFF
--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/AfterburnerTestBase.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/AfterburnerTestBase.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.module.afterburner;
 import java.io.IOException;
 import java.util.Arrays;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.*;
 
@@ -101,9 +102,11 @@ public abstract class AfterburnerTestBase extends junit.framework.TestCase
     /**
      * Sample class from Jackson tutorial ("JacksonInFiveMinutes")
      */
+    @JsonPropertyOrder(alphabetic=true)
     protected static class FiveMinuteUser {
         public enum Gender { MALE, FEMALE };
-
+	
+	@JsonPropertyOrder(alphabetic=true)
         public static class Name
         {
           private String _first, _last;

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestIssue14.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestIssue14.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -59,6 +60,8 @@ public class TestIssue14 extends AfterburnerTestBase
     }
 }
 
+@JsonPropertyOrder({ "orderId", "userId", "amount", 
+	"status", "items", "createdAt", "updatedAt"})
 class PlaceOrderRequest {
      @JsonProperty("id") public long orderId;
      @JsonProperty("from") public String userId;
@@ -69,6 +72,7 @@ class PlaceOrderRequest {
      @JsonProperty("updated_at") public Date updatedAt;
 }
      
+@JsonPropertyOrder({ "quantity", "data"}) 
 class Item {
       @JsonProperty("product_id") public int productId;
       public int quantity;

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/jdk/JDKScalarsDeserTest.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/deser/jdk/JDKScalarsDeserTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.*;
 
@@ -89,6 +90,8 @@ public class JDKScalarsDeserTest
         void setV(int v2) { super.setV(v2+1); }
     }
 
+    @JsonPropertyOrder({"booleanValue", "byteValue", "charValue", 
+    	"shortValue", "intValue", "longValue", "doubleValue"})
     static class PrimitivesBean
     {
         public boolean booleanValue = true;

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/format/MapFormatShapeTest.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/format/MapFormatShapeTest.java
@@ -65,7 +65,7 @@ public class MapFormatShapeTest extends AfterburnerTestBase
     @JsonPropertyOrder({ "property", "map" })
     static class Map1540Implementation implements Map<Integer, Integer> {
         public int property;
-        public Map<Integer, Integer> map = new HashMap<>();
+        public Map<Integer, Integer> map = new LinkedHashMap<>();
  
         public Map<Integer, Integer> getMap() {
             return map;
@@ -183,8 +183,8 @@ public class MapFormatShapeTest extends AfterburnerTestBase
     {
         Map1540Implementation input = new Map1540Implementation();
         input.property = 55;
-        input.put(12, 45);
         input.put(6, 88);
+        input.put(12, 45);
 
         String json = MAPPER.writeValueAsString(input);
 

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestInclusionAnnotations.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestInclusionAnnotations.java
@@ -7,8 +7,6 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerTestBase;
 
 public class TestInclusionAnnotations extends AfterburnerTestBase
 {
-
-    @JsonPropertyOrder({"value", "IntWrapper"})
     static class IntWrapper
     {
         @JsonInclude(JsonInclude.Include.NON_NULL) 
@@ -50,7 +48,7 @@ public class TestInclusionAnnotations extends AfterburnerTestBase
         public NonEmptyStringWrapper2(String v) { value = v; }
     }
 
-    @JsonPropertyOrder({ "name", "wrapped", "AnyWrapper"})
+    @JsonPropertyOrder({ "name", "wrapped"})
     static class AnyWrapper
     {
         public String name = "Foo";

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestInclusionAnnotations.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestInclusionAnnotations.java
@@ -1,11 +1,14 @@
 package com.fasterxml.jackson.module.afterburner.ser;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.afterburner.AfterburnerTestBase;
 
 public class TestInclusionAnnotations extends AfterburnerTestBase
 {
+
+    @JsonPropertyOrder({"value", "IntWrapper"})
     static class IntWrapper
     {
         @JsonInclude(JsonInclude.Include.NON_NULL) 
@@ -46,7 +49,8 @@ public class TestInclusionAnnotations extends AfterburnerTestBase
         public String value;
         public NonEmptyStringWrapper2(String v) { value = v; }
     }
-    
+
+    @JsonPropertyOrder({ "name", "wrapped", "AnyWrapper"})
     static class AnyWrapper
     {
         public String name = "Foo";

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestJsonFilter.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestJsonFilter.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerTestBase;
 public class TestJsonFilter extends AfterburnerTestBase
 {
     @JsonFilter("RootFilter")
+    @JsonPropertyOrder({"a", "b"})
     static class Bean {
         public String a = "a";
         public String b = "b";

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestStdSerializerOverrides.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestStdSerializerOverrides.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 public class TestStdSerializerOverrides extends AfterburnerTestBase
 {
-
     @JsonPropertyOrder(alphabetic=true)
     static class ClassWithPropOverrides
     {

--- a/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestStdSerializerOverrides.java
+++ b/afterburner/src/test/java/com/fasterxml/jackson/module/afterburner/ser/TestStdSerializerOverrides.java
@@ -12,8 +12,12 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import com.fasterxml.jackson.module.afterburner.AfterburnerTestBase;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 public class TestStdSerializerOverrides extends AfterburnerTestBase
 {
+
+    @JsonPropertyOrder(alphabetic=true)
     static class ClassWithPropOverrides
     {
         public String a = "a";

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/BlackbirdTestBase.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/BlackbirdTestBase.java
@@ -105,9 +105,11 @@ public abstract class BlackbirdTestBase extends junit.framework.TestCase
     /**
      * Sample class from Jackson tutorial ("JacksonInFiveMinutes")
      */
+    @JsonPropertyOrder(alphabetic=true)
     protected static class FiveMinuteUser {
         public enum Gender { MALE, FEMALE };
 
+	@JsonPropertyOrder(alphabetic=true)
         public static class Name
         {
           private String _first, _last;

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/TestIssue14.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/deser/TestIssue14.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -59,6 +60,8 @@ public class TestIssue14 extends BlackbirdTestBase
     }
 }
 
+@JsonPropertyOrder({ "orderId", "userId", "amount", 
+	"status", "items", "createdAt", "updatedAt"})
 class PlaceOrderRequest {
      @JsonProperty("id") public long orderId;
      @JsonProperty("from") public String userId;
@@ -69,6 +72,7 @@ class PlaceOrderRequest {
      @JsonProperty("updated_at") public Date updatedAt;
 }
 
+@JsonPropertyOrder({ "quantity", "data"}) 
 class Item {
       @JsonProperty("product_id") public int productId;
       public int quantity;

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/format/MapFormatShapeTest.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/format/MapFormatShapeTest.java
@@ -65,7 +65,7 @@ public class MapFormatShapeTest extends BlackbirdTestBase
     @JsonPropertyOrder({ "property", "map" })
     static class Map1540Implementation implements Map<Integer, Integer> {
         public int property;
-        public Map<Integer, Integer> map = new HashMap<>();
+        public Map<Integer, Integer> map = new LinkedHashMap<>();
  
         public Map<Integer, Integer> getMap() {
             return map;
@@ -183,8 +183,8 @@ public class MapFormatShapeTest extends BlackbirdTestBase
     {
         Map1540Implementation input = new Map1540Implementation();
         input.property = 55;
-        input.put(12, 45);
         input.put(6, 88);
+        input.put(12, 45);
 
         String json = MAPPER.writeValueAsString(input);
 

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestInclusionAnnotations.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestInclusionAnnotations.java
@@ -1,16 +1,17 @@
 package com.fasterxml.jackson.module.blackbird.ser;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
 
 public class TestInclusionAnnotations extends BlackbirdTestBase
 {
+    @JsonPropertyOrder({"value", "IntWrapper"})
     static class IntWrapper
     {
         @JsonInclude(JsonInclude.Include.NON_NULL) 
         public Integer value;
-        
         public IntWrapper(Integer v) { value = v; }
     }
 
@@ -47,6 +48,7 @@ public class TestInclusionAnnotations extends BlackbirdTestBase
         public NonEmptyStringWrapper2(String v) { value = v; }
     }
     
+    @JsonPropertyOrder({ "name", "wrapped", "AnyWrapper"})
     static class AnyWrapper
     {
         public String name = "Foo";

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestInclusionAnnotations.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestInclusionAnnotations.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
 
 public class TestInclusionAnnotations extends BlackbirdTestBase
 {
-    @JsonPropertyOrder({"value", "IntWrapper"})
     static class IntWrapper
     {
         @JsonInclude(JsonInclude.Include.NON_NULL) 
@@ -48,7 +47,7 @@ public class TestInclusionAnnotations extends BlackbirdTestBase
         public NonEmptyStringWrapper2(String v) { value = v; }
     }
     
-    @JsonPropertyOrder({ "name", "wrapped", "AnyWrapper"})
+    @JsonPropertyOrder({ "name", "wrapped"})
     static class AnyWrapper
     {
         public String name = "Foo";

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestJsonFilter.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestJsonFilter.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
 public class TestJsonFilter extends BlackbirdTestBase
 {
     @JsonFilter("RootFilter")
+    @JsonPropertyOrder({"a", "b"})
     static class Bean {
         public String a = "a";
         public String b = "b";

--- a/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestStdSerializerOverrides.java
+++ b/blackbird/src/test/java/com/fasterxml/jackson/module/blackbird/ser/TestStdSerializerOverrides.java
@@ -10,10 +10,13 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import com.fasterxml.jackson.module.blackbird.BlackbirdTestBase;
 
 public class TestStdSerializerOverrides extends BlackbirdTestBase
 {
+    @JsonPropertyOrder({"a", "b"})
     static class ClassWithPropOverrides
     {
         public String a = "a";


### PR DESCRIPTION
Fix 14 flaky tests using annotations and linkedhashmap. Mirror tests in blackbird module are also fixed. A ﬂaky test is an analysis of web application code that fails to produce the same result each time the same analysis is run. Flaky tests are detected by nondex (https://github.com/TestingResearchIllinois/NonDex) which is tool developped by the research group led by professor Darko at UIUC.

1.com.fasterxml.jackson.module.afterburner.deser.jdk.JDKScalarsDeserTest.testNullForPrimitivesNotAllowedMisc
2. com.fasterxml.jackson.module.afterburner.deser.TestIssue14.testIssue
3. com.fasterxml.jackson.module.afterburner.ser.TestInclusionAnnotations.testIncludeUsingAnnotation
4. com.fasterxml.jackson.module.afterburner.ser.TestJsonFilter.testMissingFilter
5. com.fasterxml.jackson.module.afterburner.ser.TestSimpleSerialize.testFiveMinuteDoc
6. com.fasterxml.jackson.module.afterburner.ser.TestStdSerializerOverrides.testStringSerWith
7. com.fasterxml.jackson.module.afterburner.format.MapFormatShapeTest#testRoundTrip