### PR TITLE
[issue172] Migrate to a Jakarta namespaced activation API.

### DIFF
--- a/jakarta-xmlbind/pom.xml
+++ b/jakarta-xmlbind/pom.xml
@@ -55,9 +55,9 @@
 
     <!-- 15-Jan-2022, tatu: as per [modules-base#152] -->
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <version>2.0.1</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>2.1.0</version>
     </dependency>
 
     <!-- may also need JAXB impl for tests -->

--- a/jakarta-xmlbind/src/main/java/com/fasterxml/jackson/module/jakarta/xmlbind/JakartaXmlBindAnnotationIntrospector.java
+++ b/jakarta-xmlbind/src/main/java/com/fasterxml/jackson/module/jakarta/xmlbind/JakartaXmlBindAnnotationIntrospector.java
@@ -717,16 +717,16 @@ public class JakartaXmlBindAnnotationIntrospector
     }
 
     /**
-     * Determines whether the type is assignable to class javax.activation.DataHandler without requiring that class
+     * Determines whether the type is assignable to class jakarta.activation.DataHandler without requiring that class
      * to be on the classpath.
      *
      * @param type The type.
-     * @return Whether the type is assignable to class javax.activation.DataHandler
+     * @return Whether the type is assignable to class jakarta.activation.DataHandler
      */
     private boolean isDataHandler(Class<?> type)
     {
         return type != null && (Object.class != type)
-               && (("javax.activation.DataHandler".equals(type.getName()) || isDataHandler(type.getSuperclass())));
+               && (("jakarta.activation.DataHandler".equals(type.getName()) || isDataHandler(type.getSuperclass())));
     }
 
     @Override

--- a/jakarta-xmlbind/src/main/java/com/fasterxml/jackson/module/jakarta/xmlbind/deser/DataHandlerDeserializer.java
+++ b/jakarta-xmlbind/src/main/java/com/fasterxml/jackson/module/jakarta/xmlbind/deser/DataHandlerDeserializer.java
@@ -5,8 +5,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/jakarta-xmlbind/src/main/java/com/fasterxml/jackson/module/jakarta/xmlbind/ser/DataHandlerSerializer.java
+++ b/jakarta-xmlbind/src/main/java/com/fasterxml/jackson/module/jakarta/xmlbind/ser/DataHandlerSerializer.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 
-import javax.activation.DataHandler;
+import jakarta.activation.DataHandler;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.JavaType;


### PR DESCRIPTION
Upstream is #176, however this one is a bit different. #152 seemed to partially solve this, but never changed the package names. I noticed it imports the implementation too instead of the API, which might be required but I'm not sure. The 2.13 won't currently compile without this change.

Let me know if the API vs the implementation is preferred and I can either change this PR or the upstream #176 one.