### PR TITLE
jaxb and jakarta-xmlbind put module-info in versions/11

### DIFF
--- a/jakarta-xmlbind/pom.xml
+++ b/jakarta-xmlbind/pom.xml
@@ -86,10 +86,6 @@
       <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
-        <inherited>true</inherited>
-        <configuration>
-          <jvmVersion>11</jvmVersion>
-        </configuration>
       </plugin>
 
     </plugins>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -94,10 +94,6 @@ for configuring data-binding.
       <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
-        <inherited>true</inherited>
-        <configuration>
-          <jvmVersion>11</jvmVersion>
-        </configuration>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
* this appears wrong and I checked the 2.15.0-SNAPSHOT jars to validate that the module-info.class ends up in versions/11 instead of versions/9
* https://github.com/FasterXML/jackson-modules-base/issues/126