### PR TITLE
Follow up wrt #191 by using `NativeImageUtil.isRunningInNativeImage()` in `databind`

### DIFF
--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
@@ -2,14 +2,20 @@ package com.fasterxml.jackson.module.afterburner;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.util.NativeImageUtil;
 import com.fasterxml.jackson.module.afterburner.ser.SerializerModifier;
 import com.fasterxml.jackson.module.afterburner.deser.DeserializerModifier;
 
 public class AfterburnerModule extends Module
     implements java.io.Serializable // is this necessary?
 {
-    // TODO: replace with jackson-databind/NativeImageUtil.RUNNING_IN_SVM
-    private static final boolean RUNNING_IN_SVM = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    /**
+     * <a href="https://github.com/FasterXML/jackson-modules-base/issues/191">[modules-base#191] Native image detection</a>
+     * 
+     * @since 2.16
+     */
+    private static final boolean RUNNING_IN_SVM = NativeImageUtil.isRunningInNativeImage();
+    
     private static final long serialVersionUID = 1L;
 
     /*

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
@@ -51,7 +51,7 @@ public class AfterburnerModule extends Module
     public void setupModule(SetupContext context)
     {
         // [modules-base#191] Since 2.16, Native image detection 
-        if (NativeImageUtil.isRunningInNativeImage())
+        if (NativeImageUtil.isInSVM())
         {
             return;
         }

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
@@ -51,7 +51,7 @@ public class AfterburnerModule extends Module
     public void setupModule(SetupContext context)
     {
         // [modules-base#191] Since 2.16, Native image detection 
-        if (NativeImageUtil.isInSVM())
+        if (NativeImageUtil.isInNativeImage())
         {
             return;
         }

--- a/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
+++ b/afterburner/src/main/java/com/fasterxml/jackson/module/afterburner/AfterburnerModule.java
@@ -9,13 +9,6 @@ import com.fasterxml.jackson.module.afterburner.deser.DeserializerModifier;
 public class AfterburnerModule extends Module
     implements java.io.Serializable // is this necessary?
 {
-    /**
-     * <a href="https://github.com/FasterXML/jackson-modules-base/issues/191">[modules-base#191] Native image detection</a>
-     * 
-     * @since 2.16
-     */
-    private static final boolean RUNNING_IN_SVM = NativeImageUtil.isRunningInNativeImage();
-    
     private static final long serialVersionUID = 1L;
 
     /*
@@ -57,7 +50,8 @@ public class AfterburnerModule extends Module
     @Override
     public void setupModule(SetupContext context)
     {
-        if (RUNNING_IN_SVM)
+        // [modules-base#191] Since 2.16, Native image detection 
+        if (NativeImageUtil.isRunningInNativeImage())
         {
             return;
         }

--- a/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
+++ b/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.blackbird;
 
+import com.fasterxml.jackson.databind.util.NativeImageUtil;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.util.function.Function;
@@ -12,8 +13,13 @@ import com.fasterxml.jackson.module.blackbird.ser.BBSerializerModifier;
 
 public class BlackbirdModule extends Module
 {
-    // TODO: replace with jackson-databind/NativeImageUtil.RUNNING_IN_SVM
-    private static final boolean RUNNING_IN_SVM = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    /**
+     * <a href="https://github.com/FasterXML/jackson-modules-base/issues/191">[modules-base#191] Native image detection</a>
+     * 
+     * @since 2.16
+     */
+    private static final boolean RUNNING_IN_SVM = NativeImageUtil.isRunningInNativeImage();
+    
     private Function<Class<?>, Lookup> _lookups;
 
     public BlackbirdModule() {

--- a/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
+++ b/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
@@ -13,13 +13,6 @@ import com.fasterxml.jackson.module.blackbird.ser.BBSerializerModifier;
 
 public class BlackbirdModule extends Module
 {
-    /**
-     * <a href="https://github.com/FasterXML/jackson-modules-base/issues/191">[modules-base#191] Native image detection</a>
-     * 
-     * @since 2.16
-     */
-    private static final boolean RUNNING_IN_SVM = NativeImageUtil.isRunningInNativeImage();
-    
     private Function<Class<?>, Lookup> _lookups;
 
     public BlackbirdModule() {
@@ -43,7 +36,8 @@ public class BlackbirdModule extends Module
     @Override
     public void setupModule(SetupContext context)
     {
-        if (RUNNING_IN_SVM)
+        // [modules-base#191] Since 2.16, Native image detection 
+        if (NativeImageUtil.isRunningInNativeImage())
         {
             return;
         }

--- a/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
+++ b/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
@@ -37,7 +37,7 @@ public class BlackbirdModule extends Module
     public void setupModule(SetupContext context)
     {
         // [modules-base#191] Since 2.16, Native image detection 
-        if (NativeImageUtil.isRunningInNativeImage())
+        if (NativeImageUtil.isInSVM())
         {
             return;
         }

--- a/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
+++ b/blackbird/src/main/java/com/fasterxml/jackson/module/blackbird/BlackbirdModule.java
@@ -37,7 +37,7 @@ public class BlackbirdModule extends Module
     public void setupModule(SetupContext context)
     {
         // [modules-base#191] Since 2.16, Native image detection 
-        if (NativeImageUtil.isInSVM())
+        if (NativeImageUtil.isInNativeImage())
         {
             return;
         }


### PR DESCRIPTION
### Motivation

Seems like the `TODO:` was written before exposing `NativeImageUtil.isRunningInNativeImage()` in `databind` by https://github.com/FasterXML/jackson-databind/pull/4060