### PR TITLE
#219 relax jakarta.xml.bind OSGI version dependency

### DIFF
--- a/jakarta-xmlbind/pom.xml
+++ b/jakarta-xmlbind/pom.xml
@@ -35,7 +35,7 @@
     <!-- 22-Mar-2019, tatu: [modules-base#80]: Presence of JAF on the bundle classpath is only necessary
            when ser/deser'ing javax.a.DataHandlers
       -->
-    <osgi.import>javax.activation;resolution:=optional,*</osgi.import>
+    <osgi.import>javax.activation;resolution:=optional,jakarta.xml.bind;version="[3.0,4.0.100)",jakarta.xml.bind.*;version="[3.0,4.0.100)",*</osgi.import>
 
     <version.xmlbind.api>3.0.1</version.xmlbind.api>
   </properties>


### PR DESCRIPTION
Generates the following `Import-Package` rules on build

```
Import-Package: jakarta.xml.bind;version="[3.0,4.0.100)",jakarta.xml.bin
 d.annotation;version="[3.0,4.0.100)",jakarta.xml.bind.annotation.adapte
 rs;version="[3.0,4.0.100)",com.fasterxml.jackson.annotation;version="[2
 .16,3)",com.fasterxml.jackson.core;version="[2.16,3)",com.fasterxml.jac
 kson.core.util;version="[2.16,3)",com.fasterxml.jackson.databind;versio
 n="[2.16,3)",com.fasterxml.jackson.databind.cfg;version="[2.16,3)",com.
 fasterxml.jackson.databind.deser.std;version="[2.16,3)",com.fasterxml.j
 ackson.databind.introspect;version="[2.16,3)",com.fasterxml.jackson.dat
 abind.jsonFormatVisitors;version="[2.16,3)",com.fasterxml.jackson.datab
 ind.jsontype;version="[2.16,3)",com.fasterxml.jackson.databind.jsontype
 .impl;version="[2.16,3)",com.fasterxml.jackson.databind.node;version="[
 2.16,3)",com.fasterxml.jackson.databind.ser.std;version="[2.16,3)",com.
 fasterxml.jackson.databind.type;version="[2.16,3)",com.fasterxml.jackso
 n.databind.util;version="[2.16,3)",com.fasterxml.jackson.module.jakarta
 .xmlbind.deser;version="[2.16,3)",com.fasterxml.jackson.module.jakarta.
 xmlbind.ser;version="[2.16,3)",jakarta.activation;version="[2.0,3)",jav
 ax.activation;resolution:=optional
```
thus enabling patch versions for jakarta.xml 4.0