### PR TITLE
Fix #219: relax jakarta.xml.bind OSGI version dependency

### DIFF
--- a/jakarta-xmlbind/pom.xml
+++ b/jakarta-xmlbind/pom.xml
@@ -33,9 +33,15 @@
     <packageVersion.dir>com/fasterxml/jackson/module/jakarta/xmlbind</packageVersion.dir>
     <packageVersion.package>${project.groupId}.jakarta.xmlbind</packageVersion.package>
     <!-- 22-Mar-2019, tatu: [modules-base#80]: Presence of JAF on the bundle classpath is only necessary
-           when ser/deser'ing javax.a.DataHandlers
+           when ser/deser'ing javax.activation.DataHandlers
       -->
-    <osgi.import>javax.activation;resolution:=optional,*</osgi.import>
+    <!-- 02-Oct-2023, tatu: [modules-base#219]: Need to relax constraints for bind-annotations
+      -->
+    <osgi.import>javax.activation;resolution:=optional,
+      jakarta.xml.bind;version="[3.0,4.0.100)",
+      jakarta.xml.bind.*;version="[3.0,4.0.100)",
+      *
+    </osgi.import>
 
     <version.xmlbind.api>3.0.1</version.xmlbind.api>
   </properties>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -128,3 +128,9 @@ René Scheibe (darxriggs@github)
 * Suggested #187: Remove stack trace from Blackbirds warnings wrt missing `MethodHandles.lookup()`
   (on Java 8)
  (2.14.0)
+
+Marco Descher (@col-panic)
+
+* Contributed fix for #219: (jakarta-xmlbind) Using `jackson-module-jakarta-xmlbind-annotations`
+  2.15.2 fails in OSGi Environment with JAXB 4
+ (2.16.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -27,6 +27,9 @@ Active maintainers:
  (fix by Steven S)
 #216: (blackbird, afterburner): Disable in native-image
  (fix by Steven S)
+#219: (jakarta-xmlbind) Using `jackson-module-jakarta-xmlbind-annotations`
+  2.15.2 fails in OSGi Environment with JAXB 4
+ (fix contributed by Marco D)
 - Update `asm` version 9.5 -> 9.6
 
 #209: Add guice7 (jakarta.inject) module


### PR DESCRIPTION
Note: replaces #221 which fails on CI (not due to PR)