### PR TITLE
feat: add subtype module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@ not datatype, data format, or JAX-RS provider modules.
     <module>mrbean</module>
     <module>osgi</module>
     <module>paranamer</module>
+    <module>subtype</module>
     <!-- since 2.13: -->
     <module>no-ctor-deser</module>
   </modules>

--- a/subtype/README.md
+++ b/subtype/README.md
@@ -1,0 +1,66 @@
+# jackson-module-subtype
+
+Registering subtypes without annotating the parent class,
+see [this](https://github.com/FasterXML/jackson-databind/issues/2104).
+
+Implementation on SPI.
+
+# Usage
+
+Registering modules.
+
+```
+ObjectMapper mapper = new ObjectMapper().registerModule(new DynamicSubtypeModule());
+```
+
+Ensure that the parent class has at least the `JsonTypeInfo` annotation.
+
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface Parent {
+}
+```
+
+1. add the `JsonSubType` annotation to your subclass.
+2. provide a non-argument constructor (SPI require it).
+
+```java
+import io.github.black.jackson.JsonSubType;
+
+@JsonSubType("first-child")
+public class FirstChild {
+
+    private String foo;
+    // ...
+
+    public FirstChild() {
+    }
+}
+```
+
+SPI: Put the subclasses in the `META-INF/services` directory under the interface.
+Example: `META-INF/services/package.Parent`
+
+```
+package.FirstChild
+```
+
+Alternatively, you can also use the `auto-service` to auto-generate these files:
+
+```java
+import io.github.black.jackson.JsonSubType;
+import com.google.auto.service.AutoService;
+
+@AutoService(Parent.class)
+@JsonSubType("first-child")
+public class FirstChild {
+
+    private String foo;
+    // ...
+
+    public FirstChild() {
+    }
+}
+```
+
+Done, enjoy it.

--- a/subtype/pom.xml
+++ b/subtype/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <!-- This module was also published with a richer model, Gradle metadata,  -->
+    <!-- which should be used instead. Do not delete the following line which  -->
+    <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+    <!-- that they should prefer consuming it instead. -->
+    <!-- do_not_remove: published-with-gradle-metadata -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-modules-base</artifactId>
+        <version>2.16.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jackson-module-subtype</artifactId>
+    <name>Jackson module: Subtype Annotation Support</name>
+    <packaging>bundle</packaging>
+
+    <description>Registering subtypes without annotating the parent class</description>
+    <url>https://github.com/FasterXML/jackson-modules-base</url>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Generate PackageVersion.java into this directory. -->
+        <packageVersion.dir>com/fasterxml/jackson/module/subtype</packageVersion.dir>
+        <packageVersion.package>com.fasterxml.jackson.module.subtype</packageVersion.package>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>1.0.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+            </plugin>
+            <!--  14-Mar-2019, tatu: Add rudimentary JDK9+ module info. To build with JDK 8
+              will have to use `moduleInfoFile` as anything else requires JDK 9+
+              -->
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/subtype/src/main/java/com/fasterxml/jackson/module/subtype/JsonSubType.java
+++ b/subtype/src/main/java/com/fasterxml/jackson/module/subtype/JsonSubType.java
@@ -1,0 +1,41 @@
+package com.fasterxml.jackson.module.subtype;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Definition of a subtype, along with optional name(s). If no name is defined
+ * (empty Strings are ignored), class of the type will be checked for {@link JsonTypeName}
+ * annotation; and if that is also missing or empty, a default
+ * name will be constructed by type id mechanism.
+ * Default name is usually based on class name.
+ * <p>
+ * It's the same as {@link  JsonSubTypes.Type}.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotation
+public @interface JsonSubType {
+    /**
+     * Logical type name used as the type identifier for the class, if defined; empty
+     * String means "not defined". Used unless {@link #names} is defined as non-empty.
+     *
+     * @return subtype name
+     */
+    String value() default "";
+
+    /**
+     * (optional) Logical type names used as the type identifier for the class: used if
+     * more than one type name should be associated with the same type.
+     *
+     * @return subtype name array
+     * @since 2.12
+     */
+    String[] names() default {};
+}

--- a/subtype/src/main/java/com/fasterxml/jackson/module/subtype/PackageVersion.java.in
+++ b/subtype/src/main/java/com/fasterxml/jackson/module/subtype/PackageVersion.java.in
@@ -1,0 +1,20 @@
+package @package@;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.Versioned;
+import com.fasterxml.jackson.core.util.VersionUtil;
+
+/**
+ * Automatically generated from PackageVersion.java.in during
+ * packageVersion-generate execution of maven-replacer-plugin in
+ * pom.xml.
+ */
+public final class PackageVersion implements Versioned {
+    public final static Version VERSION = VersionUtil.parseVersion(
+        "@projectversion@", "@projectgroupid@", "@projectartifactid@");
+
+    @Override
+    public Version version() {
+        return VERSION;
+    }
+}

--- a/subtype/src/main/java/com/fasterxml/jackson/module/subtype/SubtypeModule.java
+++ b/subtype/src/main/java/com/fasterxml/jackson/module/subtype/SubtypeModule.java
@@ -1,0 +1,120 @@
+package com.fasterxml.jackson.module.subtype;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.module.subtype.PackageVersion;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Subtype module.
+ * <p>
+ * The module caches the subclass, so it's non-real-time.
+ * It's for registering subtypes without annotating the parent class.
+ * See <a href="https://github.com/FasterXML/jackson-databind/issues/2104">this issues</a> in jackson-databind.
+ * <p>
+ * When not found in the cache, it loads and caches subclasses using SPI.
+ * Therefore, we can {@link #unregisterType} a class and then module will reload this class's subclasses.
+ */
+public class SubtypeModule extends Module {
+
+    private final ConcurrentHashMap<Class<?>, List<NamedType>> subtypes = new ConcurrentHashMap<>();
+
+    @Override
+    public String getModuleName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public Version version() {
+        return PackageVersion.VERSION;
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.insertAnnotationIntrospector(new AnnotationIntrospector() {
+            @Override
+            public Version version() {
+                return PackageVersion.VERSION;
+            }
+
+            @Override
+            public List<NamedType> findSubtypes(Annotated a) {
+                registerTypes(a.getRawType());
+
+                List<NamedType> list1 = SubtypeModule.findSubtypes(a.getRawType(), a::getAnnotation);
+                List<NamedType> list2 = subtypes.getOrDefault(a.getRawType(), Collections.emptyList());
+
+                if (list1.isEmpty()) return list2;
+                if (list2.isEmpty()) return list1;
+                List<NamedType> list = new ArrayList<>(list1.size() + list2.size());
+                list.addAll(list1);
+                list.addAll(list2);
+                return list;
+            }
+        });
+    }
+
+    /**
+     * load parent's subclass by SPI.
+     *
+     * @param parent parent class.
+     * @param <S>    parent class type.
+     */
+    @SuppressWarnings("unchecked")
+    public <S> void registerTypes(Class<S> parent) {
+        if (subtypes.containsKey(parent)) {
+            return;
+        }
+        List<Class<S>> subclasses = new ArrayList<>();
+        for (S instance : ServiceLoader.load(parent)) {
+            subclasses.add((Class<S>) instance.getClass());
+        }
+        this.registerTypes(parent, subclasses);
+    }
+
+    /**
+     * register subtypes without SPI.
+     * Of course, you need to provide them :)
+     *
+     * @param parent:     parent class.
+     * @param subclasses: children class.
+     * @param <S>:        parent class type.
+     */
+    public <S> void registerTypes(Class<S> parent, Iterable<Class<S>> subclasses) {
+        List<NamedType> result = new ArrayList<>();
+        for (Class<S> subclass : subclasses) {
+            result.addAll(findSubtypes(subclass, subclass::getAnnotation));
+        }
+        subtypes.put(parent, result);
+    }
+
+    public void unregisterType(Class<?> parent) {
+        subtypes.remove(parent);
+    }
+
+    private static <S> List<NamedType> findSubtypes(Class<S> clazz, Function<Class<JsonSubType>, JsonSubType> getter) {
+        if (clazz == null) {
+            return Collections.emptyList();
+        }
+        JsonSubType subtype = getter.apply(JsonSubType.class);
+        if (subtype == null) {
+            return Collections.emptyList();
+        }
+        List<NamedType> result = new ArrayList<>();
+        result.add(new NamedType(clazz, subtype.value()));
+        // [databind#2761]: alternative set of names to use
+        for (String name : subtype.names()) {
+            result.add(new NamedType(clazz, name));
+        }
+        return result;
+    }
+}

--- a/subtype/src/main/resources/META-INF/LICENSE
+++ b/subtype/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,8 @@
+This copy of Jackson JSON processor `jackson-module-guice` module is licensed under the
+Apache (Software) License, version 2.0 ("the License").
+See the License for details about distribution rights, and the
+specific rights regarding derivative works.
+
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0

--- a/subtype/src/main/resources/META-INF/NOTICE
+++ b/subtype/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,20 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/subtype/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/subtype/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+com.fasterxml.jackson.module.subtype.SubtypeModule

--- a/subtype/src/moditect/module-info.java
+++ b/subtype/src/moditect/module-info.java
@@ -1,0 +1,8 @@
+module com.fasterxml.jackson.module.subtype {
+
+    requires com.fasterxml.jackson.core;
+    requires com.fasterxml.jackson.annotation;
+    requires com.fasterxml.jackson.databind;
+
+    exports com.fasterxml.jackson.module.subtype;
+}

--- a/subtype/src/test/java/com/fasterxml/jackson/module/subtype/WithJsonSubTypesTest.java
+++ b/subtype/src/test/java/com/fasterxml/jackson/module/subtype/WithJsonSubTypesTest.java
@@ -1,0 +1,273 @@
+package com.fasterxml.jackson.module.subtype;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.service.AutoService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.Assert.*;
+
+/**
+ * test work with {@link JsonSubTypes}
+ */
+@RunWith(value = Parameterized.class)
+public class WithJsonSubTypesTest<T extends WithJsonSubTypesTest.Parent> {
+
+    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+    public static class Argument<T> {
+        private final Class<T> clazz;
+        private final T expected;
+
+        public Argument(Class<T> clazz, T expected) {
+            this.clazz = clazz;
+            this.expected = expected;
+        }
+    }
+
+    @Parameter
+    public Argument<T> argument;
+
+    @Parameters
+    public static Collection<Argument<?>> data() {
+        return Arrays.asList(
+                new Argument<>(FirstChild.class, new FirstChild("hello")),
+                new Argument<>(SecondChild.class, new SecondChild("world")),
+                new Argument<>(FirstAppendChild.class, new FirstAppendChild(42)),
+                new Argument<>(SecondAppendChild.class, new SecondAppendChild("42", Arrays.asList("hello", "foo", "bar"))),
+                new Argument<>(ThirdAppendChild.class, new ThirdAppendChild("42", Arrays.asList("hello", "foo", "bar"), 3.1415926))
+        );
+    }
+
+    @Test
+    public void test() throws Exception {
+        final Parent parent = argument.expected;
+        String json = mapper.writeValueAsString(parent);
+        Parent unmarshal = mapper.readValue(json, Parent.class);
+        T actual = assertInstanceOf(argument.clazz, unmarshal);
+        assertEquals(argument.expected, actual);
+    }
+
+    public static <T> T assertInstanceOf(Class<T> expectedType, Object actualValue) {
+        assertTrue(expectedType.isInstance(actualValue));
+        return expectedType.cast(actualValue);
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(value = {
+            @JsonSubTypes.Type(value = FirstChild.class, name = "first-child"),
+            @JsonSubTypes.Type(value = SecondChild.class, name = "second-child"),
+    })
+    public interface Parent {
+    }
+
+    public static class FirstChild implements Parent {
+        private String foo;
+
+        @SuppressWarnings("unused") // SPI require it
+        public FirstChild() {
+        }
+
+        public FirstChild(String foo) {
+            this.foo = foo;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public String getFoo() {
+            return foo;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FirstChild that = (FirstChild) o;
+
+            return Objects.equals(foo, that.foo);
+        }
+
+        @Override
+        public int hashCode() {
+            return foo != null ? foo.hashCode() : 0;
+        }
+    }
+
+    public static class SecondChild implements Parent {
+        private String bar;
+
+        public SecondChild() {
+        }
+
+        public SecondChild(String bar) {
+            this.bar = bar;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public String getBar() {
+            return bar;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public void setBar(String bar) {
+            this.bar = bar;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SecondChild that = (SecondChild) o;
+
+            return Objects.equals(bar, that.bar);
+        }
+
+        @Override
+        public int hashCode() {
+            return bar != null ? bar.hashCode() : 0;
+        }
+    }
+
+    @JsonSubType("first-append-child")
+    @AutoService(Parent.class)
+    public static class FirstAppendChild implements Parent {
+        private Integer integer;
+
+        @SuppressWarnings("unused") // SPI require it
+        public FirstAppendChild() {
+        }
+
+        public FirstAppendChild(Integer integer) {
+            this.integer = integer;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public Integer getInteger() {
+            return integer;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public void setInteger(Integer integer) {
+            this.integer = integer;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FirstAppendChild that = (FirstAppendChild) o;
+
+            return Objects.equals(integer, that.integer);
+        }
+
+        @Override
+        public int hashCode() {
+            return integer != null ? integer.hashCode() : 0;
+        }
+    }
+
+
+    @JsonSubType("second-append-child")
+    @AutoService(Parent.class)
+    public static class SecondAppendChild extends SecondChild {
+        private List<String> list;
+
+        public SecondAppendChild() {
+        }
+
+        public SecondAppendChild(String bar, List<String> list) {
+            super(bar);
+            this.list = list;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public List<String> getList() {
+            return list;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public void setList(List<String> list) {
+            this.list = list;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+
+            SecondAppendChild that = (SecondAppendChild) o;
+
+            return Objects.equals(list, that.list);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (list != null ? list.hashCode() : 0);
+            return result;
+        }
+    }
+
+    @JsonSubType("third-append-child")
+    @AutoService(Parent.class)
+    public static class ThirdAppendChild extends SecondAppendChild {
+        private double value;
+
+        @SuppressWarnings("unused") // SPI require it
+        public ThirdAppendChild() {
+        }
+
+        public ThirdAppendChild(String bar, List<String> list, double value) {
+            super(bar, list);
+            this.value = value;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public double getValue() {
+            return value;
+        }
+
+        @SuppressWarnings("unused") // jackson require it
+        public void setValue(double value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+
+            ThirdAppendChild that = (ThirdAppendChild) o;
+
+            return Double.compare(value, that.value) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            long temp;
+            temp = Double.doubleToLongBits(value);
+            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            return result;
+        }
+    }
+}

--- a/subtype/src/test/java/com/fasterxml/jackson/module/subtype/WithoutJsonSubTypesTest.java
+++ b/subtype/src/test/java/com/fasterxml/jackson/module/subtype/WithoutJsonSubTypesTest.java
@@ -1,0 +1,121 @@
+package com.fasterxml.jackson.module.subtype;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.service.AutoService;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * test work without {@link JsonSubTypes}
+ */
+public class WithoutJsonSubTypesTest {
+    private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    public void testFirstChild() throws Exception {
+        FirstChild child = new FirstChild();
+        child.setFoo("hello");
+        String json = mapper.writeValueAsString(child);
+
+        // {"type":"first-child","foo":"hello"}
+
+        Parent unmarshal = mapper.readValue(json, Parent.class);
+        FirstChild actual = assertInstanceOf(FirstChild.class, unmarshal);
+        assertEquals("hello", actual.getFoo());
+    }
+
+    @Test
+    public void testSecondChild() throws Exception {
+        SecondChild child = new SecondChild();
+        child.setBar("world");
+        String json = mapper.writeValueAsString(child);
+
+        // {"type":"second-child","bar":"world"}
+
+        Parent unmarshal = mapper.readValue(json, Parent.class);
+        SecondChild actual = assertInstanceOf(SecondChild.class, unmarshal);
+        assertEquals("world", actual.getBar());
+    }
+
+    public static <T> T assertInstanceOf(Class<T> expectedType, Object actualValue) {
+        assertTrue(expectedType.isInstance(actualValue));
+        return expectedType.cast(actualValue);
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    public interface Parent {
+    }
+
+    @JsonSubType("first-child")
+    @AutoService(Parent.class) // module requires spi
+    public static class FirstChild implements Parent {
+        private String foo;
+
+        public FirstChild() {
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FirstChild that = (FirstChild) o;
+
+            return Objects.equals(foo, that.foo);
+        }
+
+        @Override
+        public int hashCode() {
+            return foo != null ? foo.hashCode() : 0;
+        }
+    }
+
+
+    @JsonSubType("second-child")
+    @AutoService(Parent.class) // module requires spi
+    public static class SecondChild implements Parent {
+        private String bar;
+
+        public SecondChild() {
+        }
+
+        public String getBar() {
+            return bar;
+        }
+
+        public void setBar(String bar) {
+            this.bar = bar;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SecondChild that = (SecondChild) o;
+
+            return Objects.equals(bar, that.bar);
+        }
+
+        @Override
+        public int hashCode() {
+            return bar != null ? bar.hashCode() : 0;
+        }
+    }
+
+
+}


### PR DESCRIPTION
Adds a module that allows subtype to be registered without annotating the parent class.

It is implemented on SPI.

See https://github.com/FasterXML/jackson-databind/issues/2104

Its original version is https://github.com/black-06/jackson-modules-dynamic-subtype.

I removed the custom ServiceLoader and always use the standard library,
which means that pojo always needs a no-parameter constructor.