### PR TITLE
Allow  jackson-module-jaxb-annotations to tolerate 2.2

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -54,6 +54,14 @@ for configuring data-binding.
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <!-- Tolerate [2.2,3) for javax.xml.bind Import-Package in the generated MANIFEST.MF -->
+    <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.12</version>
+    </dependency>
+
     <!--  and actual JAXB annotations, types -->
     <!-- NOTE! Despite groupId, this is "old" JAXB, not Jakarta
          (3.x is real Jakarta one)


### PR DESCRIPTION
Resolves #233 

Screenshot showing old MANIFEST.MF (left) and updated (right).
![image](https://github.com/FasterXML/jackson-modules-base/assets/25950902/8ab19c9e-2489-42de-982b-720087ce67be)

I ran `mvnw compile` and `mvnw package` successfully.