### PR TITLE
Allow jackson-module-jaxb-annotations to tolerate 2.2,3 in Import-Package

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -54,14 +54,12 @@ for configuring data-binding.
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
-    <!--  and actual JAXB annotations, types -->
-    <!-- NOTE! Despite groupId, this is "old" JAXB, not Jakarta
-         (3.x is real Jakarta one)
-      -->
+    <!-- Tolerate [2.2,3) for javax.xml.bind Import-Package in the generated MANIFEST.MF -->
+    <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
     <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>${version.jaxb.impl}</version>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.12</version>
     </dependency>
 
     <!-- 14-Mar-2019, tatu: Looks like this is needed for JDK11 and later


### PR DESCRIPTION
Resolves #233 

I removed the Jakarta import, from the comment `Despite groupId, this is "old" JAXB, not Jakarta (3.x is real Jakarta one)` it sounds like this should be OK. The end result in the MANIFEST.MF was the same as when I just added the jaxb-api dependency above it.

<img width="1061" alt="image" src="https://github.com/FasterXML/jackson-modules-base/assets/25950902/27dc77dc-a703-4689-b4e7-8865b760c982">
