### PR TITLE
Revert "Allow jackson-module-jaxb-annotations to tolerate 2.2,3 in Import-Package"

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -54,12 +54,14 @@ for configuring data-binding.
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
-    <!-- Tolerate [2.2,3) for javax.xml.bind Import-Package in the generated MANIFEST.MF -->
-    <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+    <!--  and actual JAXB annotations, types -->
+    <!-- NOTE! Despite groupId, this is "old" JAXB, not Jakarta
+         (3.x is real Jakarta one)
+      -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.2.12</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${version.jaxb.impl}</version>
     </dependency>
 
     <!-- 14-Mar-2019, tatu: Looks like this is needed for JDK11 and later


### PR DESCRIPTION
Reverts FasterXML/jackson-modules-base#235

Not sure what on earth happened -- this got somehow merged into 2.16?!  Reverting.