### PR TITLE
android-record: Adapt generic types returned by Android reflection to follow Java behavior

### DIFF
--- a/android-record/src/main/java/com/fasterxml/jackson/module/androidrecord/AndroidRecordModule.java
+++ b/android-record/src/main/java/com/fasterxml/jackson/module/androidrecord/AndroidRecordModule.java
@@ -154,20 +154,21 @@ public class AndroidRecordModule extends SimpleModule
 
   static Type fixAndroidGenericType(Type type) {
     if (type instanceof GenericArrayType) {
-      //recurse into component type
       Type componentType = fixAndroidGenericType(((GenericArrayType) type).getGenericComponentType());
-      if (componentType instanceof Class<?>) { //if it isn't generic, return the raw array type
+      if (componentType instanceof Class<?>) {
         return arrayTypeCompat((Class<?>) componentType);
       }
     }
     else if (type instanceof ParameterizedType) {
       //if the parameterized type is not actually parameterized, deduce the raw type
       ParameterizedType parameterizedType = (ParameterizedType) type;
-      Type rawType = parameterizedType.getRawType();
-      if (rawType instanceof Class<?>) {
-        Class<?> rawComponentClass = (Class<?>) rawType;
-        if (rawComponentClass.getTypeParameters().length == 0) {
-          return rawComponentClass;
+      if (parameterizedType.getOwnerType() == null) {
+        Type rawType = parameterizedType.getRawType();
+        if (rawType instanceof Class<?>) {
+          Class<?> rawComponentClass = (Class<?>) rawType;
+          if (rawComponentClass.getTypeParameters().length == 0) {
+            return rawComponentClass;
+          }
         }
       }
     }

--- a/android-record/src/main/java/com/fasterxml/jackson/module/androidrecord/AndroidRecordModule.java
+++ b/android-record/src/main/java/com/fasterxml/jackson/module/androidrecord/AndroidRecordModule.java
@@ -1,9 +1,6 @@
 package com.fasterxml.jackson.module.androidrecord;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.Type;
+import java.lang.reflect.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -119,7 +116,7 @@ public class AndroidRecordModule extends SimpleModule
           AnnotatedConstructor constructor = (AnnotatedConstructor) creator.creator();
           Parameter[] parameters = constructor.getAnnotated().getParameters();
           Map<String, Type> parameterTypes = Arrays.stream(parameters)
-                  .collect(Collectors.toMap(Parameter::getName, Parameter::getParameterizedType));
+                  .collect(Collectors.toMap(Parameter::getName, parameter -> fixAndroidGenericType(parameter.getParameterizedType())));
 
           if (parameterTypes.equals(components)) {
             if (foundCreator != null) {
@@ -149,5 +146,31 @@ public class AndroidRecordModule extends SimpleModule
 
   static Stream<Field> getDesugaredRecordComponents(Class<?> raw) {
     return Arrays.stream(raw.getDeclaredFields()).filter(field -> !Modifier.isStatic(field.getModifiers()));
+  }
+
+  static Class<?> arrayTypeCompat(Class<?> componentType) {
+    return Array.newInstance(componentType, 0).getClass();
+  }
+
+  static Type fixAndroidGenericType(Type type) {
+    if (type instanceof GenericArrayType) {
+      //recurse into component type
+      Type componentType = fixAndroidGenericType(((GenericArrayType) type).getGenericComponentType());
+      if (componentType instanceof Class<?>) { //if it isn't generic, return the raw array type
+        return arrayTypeCompat((Class<?>) componentType);
+      }
+    }
+    else if (type instanceof ParameterizedType) {
+      //if the parameterized type is not actually parameterized, deduce the raw type
+      ParameterizedType parameterizedType = (ParameterizedType) type;
+      Type rawType = parameterizedType.getRawType();
+      if (rawType instanceof Class<?>) {
+        Class<?> rawComponentClass = (Class<?>) rawType;
+        if (rawComponentClass.getTypeParameters().length == 0) {
+          return rawComponentClass;
+        }
+      }
+    }
+    return type;
   }
 }


### PR DESCRIPTION
Fixes #251.

This PR adds a method to AndroidRecordModule that fixes/resolves GenericArrayTypes and ParameterizedTypes returned by Android reflection on method/constructor parameters. In turn, they behave the same as field types and constructor recognition on records that use both arrays and generic types no longer fails.

The type resolution method is compatible with the one in Android here: https://android.googlesource.com/platform/libcore/+/refs/heads/main/luni/src/main/java/libcore/reflect/ParameterizedTypeImpl.java#75
with the difference that it automatically resolves arrays fully where possible instead of returning an instance of GenericArrayType even on non-generic arrays (which causes errors in the current behaviour).