### PR TITLE
Fix to pass DeserializationContext along with Afterburner set calls

### DIFF
--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/BeanPropertyMutator.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/BeanPropertyMutator.java
@@ -1,5 +1,7 @@
 package tools.jackson.module.afterburner.deser;
 
+import tools.jackson.databind.DeserializationContext;
+
 /**
  * Abstract class that defines interface for implementations
  * that can be used proxy-like to change values of properties,
@@ -31,34 +33,34 @@ public abstract class BeanPropertyMutator
     //   are non-trivial, and Afterburner may be deprecated with 3.0 anyway
     //   so for now we just pass `null`
     
-    public void intSetter(Object bean, int propertyIndex, int value) {
+    public void intSetter(DeserializationContext ctxt, Object bean, int propertyIndex, int value) {
         throw new UnsupportedOperationException("No intSetters defined");
     }
-    public void longSetter(Object bean, int propertyIndex, long value){
+    public void longSetter(DeserializationContext ctxt, Object bean, int propertyIndex, long value){
         throw new UnsupportedOperationException("No longSetters defined");
     }
-    public void booleanSetter(Object bean, int propertyIndex, boolean value) {
+    public void booleanSetter(DeserializationContext ctxt, Object bean, int propertyIndex, boolean value) {
         throw new UnsupportedOperationException("No booleanSetters defined");
     }
-    public void stringSetter(Object bean, int propertyIndex, String value) {
+    public void stringSetter(DeserializationContext ctxt, Object bean, int propertyIndex, String value) {
         throw new UnsupportedOperationException("No stringSetters defined");
     }
-    public void objectSetter(Object bean, int propertyIndex, Object value) {
+    public void objectSetter(DeserializationContext ctxt, Object bean, int propertyIndex, Object value) {
         throw new UnsupportedOperationException("No objectSetters defined");
     }
-    public void intField(Object bean, int propertyIndex, int value) {
+    public void intField(DeserializationContext ctxt, Object bean, int propertyIndex, int value) {
         throw new UnsupportedOperationException("No intFields defined");
     }
-    public void longField(Object bean, int propertyIndex, long value) {
+    public void longField(DeserializationContext ctxt, Object bean, int propertyIndex, long value) {
         throw new UnsupportedOperationException("No longFields defined");
     }
-    public void booleanField(Object bean, int propertyIndex, boolean value) {
+    public void booleanField(DeserializationContext ctxt, Object bean, int propertyIndex, boolean value) {
         throw new UnsupportedOperationException("No booleanFields defined");
     }
-    public void stringField(Object bean, int propertyIndex, String value) {
+    public void stringField(DeserializationContext ctxt, Object bean, int propertyIndex, String value) {
         throw new UnsupportedOperationException("No stringFields defined");
     }
-    public void objectField(Object bean, int propertyIndex, Object value) {
+    public void objectField(DeserializationContext ctxt, Object bean, int propertyIndex, Object value) {
         throw new UnsupportedOperationException("No objectFields defined");
     }
 }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/DelegatingPropertyMutator.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/DelegatingPropertyMutator.java
@@ -1,5 +1,6 @@
 package tools.jackson.module.afterburner.deser;
 
+import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.deser.SettableBeanProperty;
 
 /**
@@ -19,44 +20,44 @@ public final class DelegatingPropertyMutator
     }
 
     @Override
-    public void intSetter(Object bean, int propertyIndex, int value) {
-        _fallback.set(null, bean, value);
+    public void intSetter(DeserializationContext ctxt, Object bean, int propertyIndex, int value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void longSetter(Object bean, int propertyIndex, long value) {
-        _fallback.set(null, bean, value);
+    public void longSetter(DeserializationContext ctxt, Object bean, int propertyIndex, long value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void booleanSetter(Object bean, int propertyIndex, boolean value) {
-        _fallback.set(null, bean, value);
+    public void booleanSetter(DeserializationContext ctxt, Object bean, int propertyIndex, boolean value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void stringSetter(Object bean, int propertyIndex, String value) {
-        _fallback.set(null, bean, value);
+    public void stringSetter(DeserializationContext ctxt, Object bean, int propertyIndex, String value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void objectSetter(Object bean, int propertyIndex, Object value) {
-        _fallback.set(null, bean, value);
+    public void objectSetter(DeserializationContext ctxt, Object bean, int propertyIndex, Object value) {
+        _fallback.set(ctxt, bean, value);
     }
 
     @Override
-    public void intField(Object bean, int propertyIndex, int value) {
-        _fallback.set(null, bean, value);
+    public void intField(DeserializationContext ctxt, Object bean, int propertyIndex, int value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void longField(Object bean, int propertyIndex, long value) {
-        _fallback.set(null, bean, value);
+    public void longField(DeserializationContext ctxt, Object bean, int propertyIndex, long value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void booleanField(Object bean, int propertyIndex, boolean value) {
-        _fallback.set(null, bean, value);
+    public void booleanField(DeserializationContext ctxt, Object bean, int propertyIndex, boolean value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void stringField(Object bean, int propertyIndex, String value) {
-        _fallback.set(null, bean, value);
+    public void stringField(DeserializationContext ctxt, Object bean, int propertyIndex, String value) {
+        _fallback.set(ctxt, bean, value);
     }
     @Override
-    public void objectField(Object bean, int propertyIndex, Object value) {
-        _fallback.set(null, bean, value);
+    public void objectField(DeserializationContext ctxt, Object bean, int propertyIndex, Object value) {
+        _fallback.set(ctxt, bean, value);
     }
 }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/PropertyMutatorCollector.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/PropertyMutatorCollector.java
@@ -190,7 +190,7 @@ public class PropertyMutatorCollector
 
     /**
      * Implementation specific to {@link PropertyMutatorCollector}
-     * We now that there are three arguments to the methods created in this case
+     * We now that there are four arguments to the methods created in this case
      */
     private static class LocalVarIndexCalculator implements AbstractPropertyStackManipulation.LocalVarIndexCalculator {
 
@@ -211,18 +211,18 @@ public class PropertyMutatorCollector
             return result;
         }
 
-        //we have 3 arguments (plus arg 0 which is 'this'), so 4 is the position of the first unless it's a long
+        //we have 4 arguments (plus arg 0 which is 'this'), so 5 is the position of the first unless it's a long
         //this would look a lot nicer if MethodVariableAccess.stackSize were public...
         @Override
         public int calculate() {
-            return 3 + (beanValueAccess == MethodVariableAccess.LONG ?  2 : 1);
+            return 4 + (beanValueAccess == MethodVariableAccess.LONG ?  2 : 1);
         }
     }
 
     private static class CreateLocalVarStackManipulation extends AbstractCreateLocalVarStackManipulation {
 
         CreateLocalVarStackManipulation(TypeDescription beanClassDescription,
-                                                MethodVariableAccess beanValueAccess) {
+                MethodVariableAccess beanValueAccess) {
             super(beanClassDescription, PropertyMutatorCollector.LocalVarIndexCalculator.of(beanValueAccess));
         }
 
@@ -300,10 +300,10 @@ public class PropertyMutatorCollector
         }
 
         /**
-         * we know that all methods of created in {@link PropertyMutatorCollector} contain the bean value as the 3rd arg
+         * we know that all methods of created in {@link PropertyMutatorCollector} contain the bean value as the 4th arg
          */
         private int beanValueArgIndex() {
-            return 3;
+            return 4;
         }
     }
 

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/PropertyMutatorCollector.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/PropertyMutatorCollector.java
@@ -223,7 +223,7 @@ public class PropertyMutatorCollector
 
         CreateLocalVarStackManipulation(TypeDescription beanClassDescription,
                 MethodVariableAccess beanValueAccess) {
-            super(beanClassDescription, PropertyMutatorCollector.LocalVarIndexCalculator.of(beanValueAccess));
+            super(beanClassDescription, PropertyMutatorCollector.LocalVarIndexCalculator.of(beanValueAccess), true);
         }
 
         private static Map<Integer, CreateLocalVarStackManipulation> cache
@@ -259,7 +259,7 @@ public class PropertyMutatorCollector
         AbstractSinglePropStackManipulation(TypeDescription beanClassDescription,
                                             T prop,
                                             MethodVariableAccess beanValueAccess) {
-            super(PropertyMutatorCollector.LocalVarIndexCalculator.of(beanValueAccess));
+            super(PropertyMutatorCollector.LocalVarIndexCalculator.of(beanValueAccess), true);
             this.beanValueAccess = beanValueAccess;
             this.beanClassDescription = beanClassDescription;
             this.prop = prop;
@@ -399,7 +399,8 @@ public class PropertyMutatorCollector
             return new UsingSwitchStackManipulation<T>(
                     LocalVarIndexCalculator.of(beanValueAccess),
                     props,
-                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess)
+                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess),
+                    true
             );
         }
 
@@ -414,7 +415,8 @@ public class PropertyMutatorCollector
             return new UsingIfStackManipulation<T>(
                     LocalVarIndexCalculator.of(beanValueAccess),
                     props,
-                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess)
+                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess),
+                    true
             );
         }
 
@@ -612,7 +614,8 @@ public class PropertyMutatorCollector
             return new UsingSwitchStackManipulation<T>(
                     LocalVarIndexCalculator.of(beanValueAccess),
                     props,
-                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess)
+                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess),
+                    true
             );
         }
 
@@ -622,7 +625,8 @@ public class PropertyMutatorCollector
             return new UsingIfStackManipulation<T>(
                     LocalVarIndexCalculator.of(beanValueAccess),
                     props,
-                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess)
+                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, beanValueAccess),
+                    true
             );
         }
 

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableBooleanFieldProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableBooleanFieldProperty.java
@@ -46,7 +46,7 @@ public final class SettableBooleanFieldProperty
             return;
         }
         try {
-            _propertyMutator.booleanField(bean, _optimizedIndex, b);
+            _propertyMutator.booleanField(ctxt, bean, _optimizedIndex, b);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, b, e);
         }
@@ -57,7 +57,7 @@ public final class SettableBooleanFieldProperty
         // not optimal (due to boxing), but better than using reflection:
         final boolean b = ((Boolean) value).booleanValue();
         try {
-            _propertyMutator.booleanField(bean, _optimizedIndex, b);
+            _propertyMutator.booleanField(ctxt, bean, _optimizedIndex, b);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, b, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableBooleanMethodProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableBooleanMethodProperty.java
@@ -46,7 +46,7 @@ public final class SettableBooleanMethodProperty
             return;
         }
         try {
-            _propertyMutator.booleanSetter(bean, _optimizedIndex, b);
+            _propertyMutator.booleanSetter(ctxt, bean, _optimizedIndex, b);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, b, e);
         }
@@ -57,7 +57,7 @@ public final class SettableBooleanMethodProperty
         // not optimal (due to boxing), but better than using reflection:
         final boolean b = ((Boolean) value).booleanValue();
         try {
-            _propertyMutator.booleanSetter(bean, _optimizedIndex, b);
+            _propertyMutator.booleanSetter(ctxt, bean, _optimizedIndex, b);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, b, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableIntFieldProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableIntFieldProperty.java
@@ -41,7 +41,7 @@ public final class SettableIntFieldProperty
         }
         final int v = p.getIntValue();
         try {
-            _propertyMutator.intField(bean, _optimizedIndex, v);
+            _propertyMutator.intField(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }
@@ -64,7 +64,7 @@ public final class SettableIntFieldProperty
         // not optimal (due to boxing), but better than using reflection:
         final int v = ((Number) value).intValue();
         try {
-            _propertyMutator.intField(bean, _optimizedIndex, v);
+            _propertyMutator.intField(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableIntMethodProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableIntMethodProperty.java
@@ -42,7 +42,7 @@ public final class SettableIntMethodProperty
         }
         final int v = p.getIntValue();
         try {
-            _propertyMutator.intSetter(bean, _optimizedIndex, v);
+            _propertyMutator.intSetter(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }
@@ -65,7 +65,7 @@ public final class SettableIntMethodProperty
         // not optimal (due to boxing), but better than using reflection:
         int v = ((Number) value).intValue();
         try {
-            _propertyMutator.intSetter(bean, _optimizedIndex, v);
+            _propertyMutator.intSetter(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableLongFieldProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableLongFieldProperty.java
@@ -41,7 +41,7 @@ public final class SettableLongFieldProperty
         }
         final long v = p.getLongValue();
         try {
-            _propertyMutator.longField(bean, _optimizedIndex, v);
+            _propertyMutator.longField(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }
@@ -64,7 +64,7 @@ public final class SettableLongFieldProperty
         // not optimal (due to boxing), but better than using reflection:
         final long v = ((Number) value).longValue();
         try {
-            _propertyMutator.longField(bean, _optimizedIndex, v);
+            _propertyMutator.longField(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableLongMethodProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableLongMethodProperty.java
@@ -42,7 +42,7 @@ public final class SettableLongMethodProperty
         }
         final long v = p.getLongValue();
         try {
-            _propertyMutator.longSetter(bean, _optimizedIndex, v);
+            _propertyMutator.longSetter(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }
@@ -65,7 +65,7 @@ public final class SettableLongMethodProperty
         // not optimal (due to boxing), but better than using reflection:
         final long v = ((Number) value).longValue();
         try {
-            _propertyMutator.longSetter(bean, _optimizedIndex, v);
+            _propertyMutator.longSetter(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableObjectFieldProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableObjectFieldProperty.java
@@ -55,7 +55,7 @@ public final class SettableObjectFieldProperty
             value = _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
         }
         try {
-            _propertyMutator.objectField(bean, _optimizedIndex, value);
+            _propertyMutator.objectField(ctxt, bean, _optimizedIndex, value);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, value, e);
         }
@@ -91,7 +91,7 @@ public final class SettableObjectFieldProperty
     public void set(DeserializationContext ctxt, Object bean, Object v)
     {
         try {
-            _propertyMutator.objectField(bean, _optimizedIndex, v);
+            _propertyMutator.objectField(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableObjectMethodProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableObjectMethodProperty.java
@@ -55,7 +55,7 @@ public final class SettableObjectMethodProperty
             value = _valueDeserializer.deserializeWithType(p, ctxt, _valueTypeDeserializer);
         }
         try {
-            _propertyMutator.objectSetter(bean, _optimizedIndex, value);
+            _propertyMutator.objectSetter(ctxt, bean, _optimizedIndex, value);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, value, e);
         }
@@ -91,7 +91,7 @@ public final class SettableObjectMethodProperty
     public void set(DeserializationContext ctxt, Object bean, Object v)
     {
         try {
-            _propertyMutator.objectSetter(bean, _optimizedIndex, v);
+            _propertyMutator.objectSetter(ctxt, bean, _optimizedIndex, v);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, v, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableStringFieldProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableStringFieldProperty.java
@@ -42,7 +42,7 @@ public final class SettableStringFieldProperty
         }
         final String text = p.getText();
         try {
-            _propertyMutator.stringField(bean, _optimizedIndex, text);
+            _propertyMutator.stringField(ctxt, bean, _optimizedIndex, text);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, text, e);
         }
@@ -63,7 +63,7 @@ public final class SettableStringFieldProperty
     {
         final String text = (String) value;
         try {
-            _propertyMutator.stringField(bean, _optimizedIndex, text);
+            _propertyMutator.stringField(ctxt, bean, _optimizedIndex, text);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, text, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableStringMethodProperty.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/deser/SettableStringMethodProperty.java
@@ -42,7 +42,7 @@ public final class SettableStringMethodProperty
         }
         final String text = p.getText();
         try {
-            _propertyMutator.stringSetter(bean, _optimizedIndex, text);
+            _propertyMutator.stringSetter(ctxt, bean, _optimizedIndex, text);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, text, e);
         }
@@ -63,7 +63,7 @@ public final class SettableStringMethodProperty
     {
         final String text = (String) value;
         try {
-            _propertyMutator.stringSetter(bean, _optimizedIndex, text);
+            _propertyMutator.stringSetter(ctxt, bean, _optimizedIndex, text);
         } catch (Throwable e) {
             _reportProblem(ctxt, bean, text, e);
         }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/ser/PropertyAccessorCollector.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/ser/PropertyAccessorCollector.java
@@ -197,7 +197,7 @@ public class PropertyAccessorCollector
     private static class CreateLocalVarStackManipulation extends AbstractCreateLocalVarStackManipulation {
 
         CreateLocalVarStackManipulation(TypeDescription beanClassDescription) {
-            super(beanClassDescription, PropertyAccessorCollector.LocalVarIndexCalculator.INSTANCE);
+            super(beanClassDescription, PropertyAccessorCollector.LocalVarIndexCalculator.INSTANCE, false);
         }
 
         private static Map<TypeDescription, CreateLocalVarStackManipulation> cache
@@ -226,7 +226,7 @@ public class PropertyAccessorCollector
         AbstractSinglePropStackManipulation(TypeDescription beanClassDescription,
                                         T prop,
                                         MethodReturn methodReturn) {
-            super(PropertyAccessorCollector.LocalVarIndexCalculator.INSTANCE);
+            super(PropertyAccessorCollector.LocalVarIndexCalculator.INSTANCE, false);
             this.methodReturn = methodReturn;
             this.beanClassDescription = beanClassDescription;
             this.prop = prop;
@@ -396,7 +396,8 @@ public class PropertyAccessorCollector
             return new UsingSwitchStackManipulation<T>(
                     LocalVarIndexCalculator.INSTANCE,
                     props,
-                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, methodReturn)
+                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, methodReturn),
+                    false
             );
         }
 
@@ -411,7 +412,8 @@ public class PropertyAccessorCollector
             return new UsingIfStackManipulation<>(
                     LocalVarIndexCalculator.INSTANCE,
                     props,
-                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, methodReturn)
+                    SingleMethodStackManipulationSupplier.<T>of(beanClassDescription, methodReturn),
+                    false
             );
         }
 
@@ -540,7 +542,8 @@ public class PropertyAccessorCollector
             return new UsingSwitchStackManipulation<T>(
                     LocalVarIndexCalculator.INSTANCE,
                     props,
-                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, methodReturn)
+                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, methodReturn),
+                    false
             );
         }
 
@@ -555,7 +558,8 @@ public class PropertyAccessorCollector
             return new UsingIfStackManipulation<>(
                     LocalVarIndexCalculator.INSTANCE,
                     props,
-                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, methodReturn)
+                    SingleFieldStackManipulationSupplier.<T>of(beanClassDescription, methodReturn),
+                    false
             );
         }
 

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/AbstractCreateLocalVarStackManipulation.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/AbstractCreateLocalVarStackManipulation.java
@@ -26,8 +26,9 @@ public abstract class AbstractCreateLocalVarStackManipulation extends AbstractPr
 
     public AbstractCreateLocalVarStackManipulation(
             TypeDescription beanClassDescription,
-            AbstractPropertyStackManipulation.LocalVarIndexCalculator localVarIndexCalculator) {
-        super(localVarIndexCalculator);
+            AbstractPropertyStackManipulation.LocalVarIndexCalculator localVarIndexCalculator,
+            boolean isForMutator) {
+        super(localVarIndexCalculator, isForMutator);
         this.beanClassDescription = beanClassDescription;
     }
 

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/AbstractPropertyStackManipulation.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/AbstractPropertyStackManipulation.java
@@ -11,9 +11,11 @@ import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
 public abstract class AbstractPropertyStackManipulation implements StackManipulation {
 
     protected final LocalVarIndexCalculator localVarIndexCalculator;
+    private final boolean isForMutator;
 
-    public AbstractPropertyStackManipulation(LocalVarIndexCalculator localVarIndexCalculator) {
+    public AbstractPropertyStackManipulation(LocalVarIndexCalculator localVarIndexCalculator, boolean isForMutator) {
         this.localVarIndexCalculator = localVarIndexCalculator;
+        this.isForMutator = isForMutator;
     }
 
     @Override
@@ -22,11 +24,11 @@ public abstract class AbstractPropertyStackManipulation implements StackManipula
     }
 
     public final int beanArgIndex() {
-        return 1;
+        return 1 + (isForMutator ? 1 : 0);
     }
 
     public final int fieldIndexArgIndex() {
-        return 2;
+        return 2  + (isForMutator ? 1 : 0);
     }
 
     public final StackManipulation loadFieldIndexArg() {

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/UsingIfStackManipulation.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/UsingIfStackManipulation.java
@@ -49,8 +49,9 @@ public class UsingIfStackManipulation<T> extends AbstractPropertyStackManipulati
 
     public UsingIfStackManipulation(LocalVarIndexCalculator localVarIndexCalculator,
                                     List<T> props,
-                                    SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier) {
-        super(localVarIndexCalculator);
+                                    SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier,
+                                    boolean isForMutator) {
+        super(localVarIndexCalculator, isForMutator);
         this.props = props;
         this.singlePropStackManipulationSupplier = singlePropStackManipulationSupplier;
     }

--- a/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/UsingSwitchStackManipulation.java
+++ b/afterburner/src/main/java/tools/jackson/module/afterburner/util/bytebuddy/UsingSwitchStackManipulation.java
@@ -60,8 +60,9 @@ public class UsingSwitchStackManipulation<T> extends AbstractPropertyStackManipu
 
     public UsingSwitchStackManipulation(LocalVarIndexCalculator localVarIndexCalculator,
                                         List<T> props,
-                                        SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier) {
-        super(localVarIndexCalculator);
+                                        SinglePropStackManipulationSupplier<T> singlePropStackManipulationSupplier,
+                                        boolean isForMutator) {
+        super(localVarIndexCalculator, isForMutator);
         this.props = props;
         this.singlePropStackManipulationSupplier = singlePropStackManipulationSupplier;
     }


### PR DESCRIPTION
(NOTE: not yet working)

As initial change to comply with newly added argument to `SettableBeanProperty.set()` (first arg, `DeserializationContext`) we pass just `null`. But ideally we would pass context through to generated mutator which might want to use it. This addition only applies to Jackson 3.0.

