### PR TITLE
[`master`] fix failing tests after `FAIL_ON_NULL_FOR_PRIMITIVES` to `true` [databind#4890]

### DIFF
--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/TestCreators2.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/TestCreators2.java
@@ -2,7 +2,6 @@
 package tools.jackson.module.afterburner.deser;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/TestCreators2.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/TestCreators2.java
@@ -2,6 +2,7 @@
 package tools.jackson.module.afterburner.deser;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 
@@ -229,7 +230,9 @@ public class TestCreators2 extends AfterburnerTestBase
     // Test for [JACKSON-372]
     public void testMissingPrimitives() throws Exception
     {
-        Primitives p = MAPPER.readValue("{}", Primitives.class);
+        Primitives p = MAPPER.readerFor(Primitives.class)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .readValue("{}");
         assertFalse(p.b);
         assertEquals(0, p.x);
         assertEquals(0.0, p.d);

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/CoerceJDKScalarsTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/CoerceJDKScalarsTest.java
@@ -79,6 +79,7 @@ public class CoerceJDKScalarsTest extends AfterburnerTestBase
     {
         Object result = COERCING_MAPPER.readerFor(type)
                 .with(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .readValue("\"\"");
         if (exp == null) {
             assertNull(result);

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/CoerceStringToIntsTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/CoerceStringToIntsTest.java
@@ -32,6 +32,7 @@ public class CoerceStringToIntsTest extends AfterburnerTestBase
     private final ObjectMapper MAPPER_TO_NULL = afterburnerMapperBuilder()
             .withCoercionConfig(LogicalType.Integer, cfg ->
             cfg.setCoercion(CoercionInputShape.String, CoercionAction.AsNull))
+        .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
         .build();
 
     private final ObjectMapper MAPPER_TO_FAIL = afterburnerMapperBuilder()

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/CoerceToBooleanTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/CoerceToBooleanTest.java
@@ -222,22 +222,25 @@ public class CoerceToBooleanTest extends AfterburnerTestBase
     // Test for verifying that Long values are coerced to boolean correctly as well
     public void testLongToBooleanCoercionOk() throws Exception
     {
+        ObjectReader r = DEFAULT_MAPPER.reader()
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+
         long value = 1L + Integer.MAX_VALUE;
-        BooleanWrapper b = DEFAULT_MAPPER.readValue("{\"primitive\" : "+value+", \"wrapper\":"+value+", \"ctor\":"+value+"}",
-                BooleanWrapper.class);
+        BooleanWrapper b = r.forType(BooleanWrapper.class)
+                .readValue("{\"primitive\" : "+value+", \"wrapper\":"+value+", \"ctor\":"+value+"}");
         assertEquals(Boolean.TRUE, b.wrapper);
         assertTrue(b.primitive);
         assertEquals(Boolean.TRUE, b.ctor);
 
         // but ensure we can also get `false`
-        b = DEFAULT_MAPPER.readValue("{\"primitive\" : 0 , \"wrapper\":0, \"ctor\":0}",
-                BooleanWrapper.class);
+        b = r.forType(BooleanWrapper.class)
+                .readValue("{\"primitive\" : 0 , \"wrapper\":0, \"ctor\":0}");
         assertEquals(Boolean.FALSE, b.wrapper);
         assertFalse(b.primitive);
         assertEquals(Boolean.FALSE, b.ctor);
 
-        boolean[] boo = DEFAULT_MAPPER.readValue("[ 0, 15, \"\", \"false\", \"True\" ]",
-                boolean[].class);
+        boolean[] boo = r.forType(boolean[].class)
+                .readValue("[ 0, 15, \"\", \"false\", \"True\" ]");
         assertEquals(5, boo.length);
         assertFalse(boo[0]);
         assertTrue(boo[1]);

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/TestFailOnPrimitiveFromNullDeserialization.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/convert/TestFailOnPrimitiveFromNullDeserialization.java
@@ -30,7 +30,9 @@ public class TestFailOnPrimitiveFromNullDeserialization
 
     private final static String BEAN_WITH_NULL_VALUE = "{\"value\": null}";
 
-    private final ObjectMapper MAPPER = newAfterburnerMapper();
+    private final ObjectMapper MAPPER = afterburnerMapperBuilder()
+        .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+        .build();
     private final ObjectMapper FAIL_ON_NULL_MAPPER = afterburnerMapperBuilder()
         .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
         .build();

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/filter/NullConversionsForContentTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/filter/NullConversionsForContentTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.*;
 import tools.jackson.databind.exc.InvalidNullException;
+import tools.jackson.databind.node.ValueNode;
 import tools.jackson.module.afterburner.AfterburnerTestBase;
 
 // For [databind#1402]; configurable null handling, for contents of
@@ -248,24 +249,30 @@ public class NullConversionsForContentTest extends AfterburnerTestBase
 
         // int[]
         {
-            NullContentAsEmpty<int[]> result = MAPPER.readValue(JSON,
-                    new TypeReference<NullContentAsEmpty<int[]>>() { });
+            NullContentAsEmpty<int[]> result = MAPPER.readerFor(
+                    new TypeReference<NullContentAsEmpty<int[]>>() { })
+                    .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                    .readValue(JSON);
             assertEquals(1, result.values.length);
             assertEquals(0, result.values[0]);
         }
 
         // long[]
         {
-            NullContentAsEmpty<long[]> result = MAPPER.readValue(JSON,
-                    new TypeReference<NullContentAsEmpty<long[]>>() { });
+            NullContentAsEmpty<long[]> result = MAPPER.readerFor(
+                    new TypeReference<NullContentAsEmpty<long[]>>() { })
+                    .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                    .readValue(JSON);
             assertEquals(1, result.values.length);
             assertEquals(0L, result.values[0]);
         }
 
         // boolean[]
         {
-            NullContentAsEmpty<boolean[]> result = MAPPER.readValue(JSON,
-                    new TypeReference<NullContentAsEmpty<boolean[]>>() { });
+            NullContentAsEmpty<boolean[]> result = MAPPER.readerFor(
+                    new TypeReference<NullContentAsEmpty<boolean[]>>() { })
+                    .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                    .readValue(JSON);
             assertEquals(1, result.values.length);
             assertEquals(false, result.values[0]);
         }

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/filter/NullConversionsForContentTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/filter/NullConversionsForContentTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.Nulls;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.*;
 import tools.jackson.databind.exc.InvalidNullException;
-import tools.jackson.databind.node.ValueNode;
 import tools.jackson.module.afterburner.AfterburnerTestBase;
 
 // For [databind#1402]; configurable null handling, for contents of

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/jdk/JDKScalarsDeserTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/jdk/JDKScalarsDeserTest.java
@@ -26,7 +26,9 @@ import tools.jackson.module.afterburner.AfterburnerTestBase;
 public class JDKScalarsDeserTest
     extends AfterburnerTestBase
 {
-    private final ObjectMapper MAPPER = newAfterburnerMapper();
+    private final ObjectMapper MAPPER = mapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
 
     private final static String NAN_STRING = "NaN";
 

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/merge/ArrayMergeTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/merge/ArrayMergeTest.java
@@ -88,6 +88,7 @@ public class ArrayMergeTest extends AfterburnerTestBase
         MergedX<byte[]> input = new MergedX<byte[]>(new byte[] { 1, 2 });
         MergedX<byte[]> result = MAPPER
                 .readerFor(new TypeReference<MergedX<byte[]>>() {})
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .withValueToUpdate(input)
                 .readValue(aposToQuotes("{'value':[4, 6.0, null]}"));
         assertSame(input, result);

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/deser/struct/ScalarCoercionTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/deser/struct/ScalarCoercionTest.java
@@ -58,6 +58,7 @@ public class ScalarCoercionTest extends AfterburnerTestBase
     {
         Object result = COERCING_MAPPER.readerFor(type)
                 .with(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .readValue("\"\"");
         if (exp == null) {
             assertNull(result);

--- a/afterburner/src/test/java/tools/jackson/module/afterburner/roundtrip/BiggerDataTest.java
+++ b/afterburner/src/test/java/tools/jackson/module/afterburner/roundtrip/BiggerDataTest.java
@@ -78,7 +78,9 @@ public class BiggerDataTest extends AfterburnerTestBase
     /**********************************************************
      */
 
-    private final ObjectMapper MAPPER = newAfterburnerMapper();
+    private final ObjectMapper MAPPER = mapperBuilder()
+			.disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+			.build();
 
     public void testReading() throws Exception
     {

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/TestCreators2.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/TestCreators2.java
@@ -229,6 +229,7 @@ public class TestCreators2 extends BlackbirdTestBase
     {
         Primitives p = MAPPER
             .readerFor(Primitives.class)
+            .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
             .readValue("{}");
         assertFalse(p.b);
         assertEquals(0, p.x);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/TestCreators2.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/TestCreators2.java
@@ -227,7 +227,9 @@ public class TestCreators2 extends BlackbirdTestBase
     // Test for [JACKSON-372]
     public void testMissingPrimitives() throws Exception
     {
-        Primitives p = MAPPER.readValue("{}", Primitives.class);
+        Primitives p = MAPPER
+            .readerFor(Primitives.class)
+            .readValue("{}");
         assertFalse(p.b);
         assertEquals(0, p.x);
         assertEquals(0.0, p.d);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/CoerceJDKScalarsTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/CoerceJDKScalarsTest.java
@@ -79,6 +79,7 @@ public class CoerceJDKScalarsTest extends BlackbirdTestBase
     {
         Object result = COERCING_MAPPER.readerFor(type)
                 .with(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .readValue("\"\"");
         if (exp == null) {
             assertNull(result);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/CoerceStringToIntsTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/CoerceStringToIntsTest.java
@@ -32,6 +32,7 @@ public class CoerceStringToIntsTest extends BlackbirdTestBase
     private final ObjectMapper MAPPER_TO_NULL = mapperBuilder()
             .withCoercionConfig(LogicalType.Integer, cfg ->
             cfg.setCoercion(CoercionInputShape.String, CoercionAction.AsNull))
+        .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
         .build();
 
     private final ObjectMapper MAPPER_TO_FAIL = mapperBuilder()

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/CoerceToBooleanTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/CoerceToBooleanTest.java
@@ -222,22 +222,25 @@ public class CoerceToBooleanTest extends BlackbirdTestBase
     // Test for verifying that Long values are coerced to boolean correctly as well
     public void testLongToBooleanCoercionOk() throws Exception
     {
+        ObjectReader r = DEFAULT_MAPPER.reader()
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+
         long value = 1L + Integer.MAX_VALUE;
-        BooleanWrapper b = DEFAULT_MAPPER.readValue("{\"primitive\" : "+value+", \"wrapper\":"+value+", \"ctor\":"+value+"}",
-                BooleanWrapper.class);
+        BooleanWrapper b = r.forType(BooleanWrapper.class)
+                .readValue("{\"primitive\" : "+value+", \"wrapper\":"+value+", \"ctor\":"+value+"}");
         assertEquals(Boolean.TRUE, b.wrapper);
         assertTrue(b.primitive);
         assertEquals(Boolean.TRUE, b.ctor);
 
         // but ensure we can also get `false`
-        b = DEFAULT_MAPPER.readValue("{\"primitive\" : 0 , \"wrapper\":0, \"ctor\":0}",
-                BooleanWrapper.class);
+        b = r.forType(BooleanWrapper.class)
+                .readValue("{\"primitive\" : 0 , \"wrapper\":0, \"ctor\":0}");
         assertEquals(Boolean.FALSE, b.wrapper);
         assertFalse(b.primitive);
         assertEquals(Boolean.FALSE, b.ctor);
 
-        boolean[] boo = DEFAULT_MAPPER.readValue("[ 0, 15, \"\", \"false\", \"True\" ]",
-                boolean[].class);
+        boolean[] boo = r.forType(boolean[].class)
+                .readValue("[ 0, 15, \"\", \"false\", \"True\" ]");
         assertEquals(5, boo.length);
         assertFalse(boo[0]);
         assertTrue(boo[1]);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/TestFailOnPrimitiveFromNullDeserialization.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/convert/TestFailOnPrimitiveFromNullDeserialization.java
@@ -44,10 +44,14 @@ public class TestFailOnPrimitiveFromNullDeserialization extends BlackbirdTestBas
 
     public void testPassPrimitiveFromNull() throws Exception
     {
-        LongBean longBean = MAPPER.readValue(BEAN_WITH_NULL_VALUE, LongBean.class);
-        IntBean intBean = MAPPER.readValue(BEAN_WITH_NULL_VALUE, IntBean.class);
-        BooleanBean booleanBean = MAPPER.readValue(BEAN_WITH_NULL_VALUE, BooleanBean.class);
-        DoubleBean doubleBean = MAPPER.readValue(BEAN_WITH_NULL_VALUE, DoubleBean.class);
+        ObjectMapper mapper = mapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
+
+        LongBean longBean = mapper.readValue(BEAN_WITH_NULL_VALUE, LongBean.class);
+        IntBean intBean = mapper.readValue(BEAN_WITH_NULL_VALUE, IntBean.class);
+        BooleanBean booleanBean = mapper.readValue(BEAN_WITH_NULL_VALUE, BooleanBean.class);
+        DoubleBean doubleBean = mapper.readValue(BEAN_WITH_NULL_VALUE, DoubleBean.class);
         assertEquals(longBean.value, 0);
         assertEquals(intBean.value, 0);
         assertEquals(booleanBean.value, false);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/filter/NullConversionsForContentTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/filter/NullConversionsForContentTest.java
@@ -246,28 +246,33 @@ public class NullConversionsForContentTest extends BlackbirdTestBase
 
     public void testNullsAsEmptyWithPrimitiveArrays() throws Exception
     {
+        ObjectReader r = MAPPER.reader().without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+
         final String JSON = aposToQuotes("{'values':[null]}");
 
         // int[]
         {
-            NullContentAsEmpty<int[]> result = MAPPER.readValue(JSON,
-                    new TypeReference<NullContentAsEmpty<int[]>>() { });
+            NullContentAsEmpty<int[]> result = r.forType(
+                    new TypeReference<NullContentAsEmpty<int[]>>() { })
+                    .readValue(JSON);
             assertEquals(1, result.values.length);
             assertEquals(0, result.values[0]);
         }
 
         // long[]
         {
-            NullContentAsEmpty<long[]> result = MAPPER.readValue(JSON,
-                    new TypeReference<NullContentAsEmpty<long[]>>() { });
+            NullContentAsEmpty<long[]> result = r.forType(
+                    new TypeReference<NullContentAsEmpty<long[]>>() { })
+                    .readValue(JSON);
             assertEquals(1, result.values.length);
             assertEquals(0L, result.values[0]);
         }
 
         // boolean[]
         {
-            NullContentAsEmpty<boolean[]> result = MAPPER.readValue(JSON,
-                    new TypeReference<NullContentAsEmpty<boolean[]>>() { });
+            NullContentAsEmpty<boolean[]> result = r.forType(
+                    new TypeReference<NullContentAsEmpty<boolean[]>>() { })
+                    .readValue(JSON);
             assertEquals(1, result.values.length);
             assertEquals(false, result.values[0]);
         }

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/jdk/JDKScalarsDeserTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/jdk/JDKScalarsDeserTest.java
@@ -28,7 +28,9 @@ import org.junit.Assert;
 public class JDKScalarsDeserTest
     extends BlackbirdTestBase
 {
-    private final ObjectMapper MAPPER = newObjectMapper();
+    private final ObjectMapper MAPPER = mapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
 
     private final static String NAN_STRING = "NaN";
 

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/merge/ArrayMergeTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/merge/ArrayMergeTest.java
@@ -89,6 +89,7 @@ public class ArrayMergeTest extends BlackbirdTestBase
         MergedX<byte[]> input = new MergedX<byte[]>(new byte[] { 1, 2 });
         MergedX<byte[]> result = MAPPER
                 .readerFor(new TypeReference<MergedX<byte[]>>() {})
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .withValueToUpdate(input)
                 .readValue(aposToQuotes("{'value':[4, 6.0, null]}"));
         assertSame(input, result);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/struct/ScalarCoercionTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/struct/ScalarCoercionTest.java
@@ -58,6 +58,7 @@ public class ScalarCoercionTest extends BlackbirdTestBase
     {
         Object result = COERCING_MAPPER.readerFor(type)
                 .with(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .readValue("\"\"");
         if (exp == null) {
             assertNull(result);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/deser/struct/ScalarCoercionTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/deser/struct/ScalarCoercionTest.java
@@ -58,7 +58,7 @@ public class ScalarCoercionTest extends BlackbirdTestBase
     {
         Object result = COERCING_MAPPER.readerFor(type)
                 .with(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
-                .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .readValue("\"\"");
         if (exp == null) {
             assertNull(result);

--- a/blackbird/src/test/java/tools/jackson/module/blackbird/roundtrip/BiggerDataTest.java
+++ b/blackbird/src/test/java/tools/jackson/module/blackbird/roundtrip/BiggerDataTest.java
@@ -78,9 +78,12 @@ public class BiggerDataTest extends BlackbirdTestBase
     /**********************************************************
      */
 
-    private final ObjectMapper MAPPER = newBlackbirdMapper();
+    private final ObjectMapper MAPPER = blackbirdMapperBuilder()
+			.disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+			.build();
 
-    public void testReading() throws Exception
+
+	public void testReading() throws Exception
     {
         Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"),
                 Citm.class);


### PR DESCRIPTION
Resolves failing tests affected by https://github.com/FasterXML/jackson-databind/issues/4858