### PR TITLE
Update LICENSE for jackson-module-blackbird

### DIFF
--- a/blackbird/src/main/resources/META-INF/LICENSE
+++ b/blackbird/src/main/resources/META-INF/LICENSE
@@ -1,4 +1,4 @@
-This copy of Jackson JSON processor `jackson-module-afterburner` module is licensed under the
+This copy of Jackson JSON processor `jackson-module-blackbird` module is licensed under the
 Apache (Software) License, version 2.0 ("the License").
 See the License for details about distribution rights, and the
 specific rights regarding derivative works.


### PR DESCRIPTION
Fixes the packaged license file to reference the module being packaged.

Looks like this may have been overlooked when blackbird was created from the old afterburner impl.